### PR TITLE
CVE-2025-22871: Bump Go toolchain to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module junitparser
 
 go 1.23.0
 
-toolchain go1.23.7
+toolchain go1.23.8
 
 require (
 	k8s.io/api v0.32.4


### PR DESCRIPTION
This PR addresses CVE-2025-22871 which bumps the Go toolchain version from `1.23.7` to `1.23.8` according to the [Vulnerability Report](https://pkg.go.dev/vuln/GO-2025-3563)