### PR TITLE
CNV-81819: add storageprofile label to pvc and fix capabilities for GCP hyperdisk

### DIFF
--- a/manifests/run/04_pvc.yaml
+++ b/manifests/run/04_pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ocp-virt-validation
   labels:
     app: ocp-virt-validation
+    cdi.kubevirt.io/applyStorageProfile: "true"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -130,6 +130,7 @@ roleRef:
 EOF
 
 # PVC (to store the results)
+# cdi.kubevirt.io/applyStorageProfile: "true" lets CDI apply StorageProfile so requested size is raised to the CSI driver minimum when smaller.
 cat <<EOF
 ---
 apiVersion: v1
@@ -139,6 +140,7 @@ metadata:
   namespace: ocp-virt-validation
   labels:
     app: ocp-virt-validation
+    cdi.kubevirt.io/applyStorageProfile: "true"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/scripts/kubevirt/config/storage/kubevirt-tier1-hyperdisk.json
+++ b/scripts/kubevirt/config/storage/kubevirt-tier1-hyperdisk.json
@@ -4,6 +4,8 @@
     "storageRWXBlock":         "sp-balanced-storage",
     "storageRWOFileSystem":    "sp-balanced-storage",
     "storageRWOBlock":         "sp-balanced-storage",
-    "storageSnapshot":         "sp-balanced-storage-rwo",
-    "storageClassCSI":         "sp-balanced-storage-rwo"
+    "storageClassCSI":         "sp-balanced-storage",
+    "storageSnapshot":         "sp-balanced-storage",
+    "onlineResize":            "sp-balanced-storage",
+    "WFFC":                    "sp-balanced-storage"
 }


### PR DESCRIPTION
adding `cdi.kubevirt.io/applyStorageProfile: "true"` label to the pvc so StorageProfile will mitigate the minimum size defined by the csi driver (for GCP hyperdisk, its 4Gi)

### before this fix:
creating 2Gi pvc (for the validation) fails.
### after this fix:
creating 2Gi pvc passes and will use minimum size instead (for hyperdisk, creating 2Gi will result in a 4Gi pvc)

Also:

1. for GCP hyperdisk, thanks to https://github.com/kubevirt/containerized-data-importer/pull/399, `sp-balanced-storage-rwo` storageclass is no longer needed
2. adding onlineResize and WFFC capabilities


Jira: https://redhat.atlassian.net/browse/CNV-81819