### PR TITLE
CNV-80558: Rename `nginx-conf` ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ The command output would look similar to:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: pvc-reader-nginx-conf
   namespace: ocp-virt-validation
 data:
   nginx.conf: |-
@@ -466,7 +466,7 @@ spec:
         claimName: ocp-virt-validation-pvc-20250518-112311
     - name: conf
       configMap:
-        name: nginx-conf
+        name: pvc-reader-nginx-conf
         items:
           - key: nginx.conf
             path: nginx.conf
@@ -512,7 +512,7 @@ spec:
 **Note:** You can apply the manifests directly from the command, using:
 ```bash
 $ podman run -e TIMESTAMP=${TIMESTAMP} ${OCP_VIRT_VALIDATION_IMAGE} get_results | oc apply -f -
-configmap/nginx-conf created
+configmap/pvc-reader-nginx-conf created
 pod/pvc-reader-20250518-112311 created
 service/pvc-reader created
 route.route.openshift.io/pvcreader created

--- a/manifests/fetch/01_configmap.yaml
+++ b/manifests/fetch/01_configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
-  namespace: cnv-cert
+  name: pvc-reader-nginx-conf
+  namespace: ocp-virt-validation
 data:
   nginx.conf: |-
     user nginx;

--- a/manifests/fetch/02_nginx_pod.yaml
+++ b/manifests/fetch/02_nginx_pod.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: pvc-reader
   name: pvc-reader-$(date +%s)
-  namespace: cnv-cert
+  namespace: ocp-virt-validation
 spec:
   containers:
     - image: registry.redhat.io/rhel9/nginx-124:latest
@@ -28,7 +28,7 @@ spec:
         claimName: ${PVC_NAME}
     - name: conf
       configMap:
-        name: nginx-conf
+        name: pvc-reader-nginx-conf
         items:
           - key: nginx.conf
             path: nginx.conf

--- a/manifests/fetch/03_service.yaml
+++ b/manifests/fetch/03_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: pvc-reader
   name: pvc-reader
-  namespace: cnv-cert
+  namespace: ocp-virt-validation
 spec:
   ports:
     - name: nginx

--- a/manifests/fetch/04_route.yaml
+++ b/manifests/fetch/04_route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: pvcreader
-  namespace: cnv-cert
+  namespace: ocp-virt-validation
 spec:
   path: /
   port:

--- a/manifests/fetch/get_results.sh
+++ b/manifests/fetch/get_results.sh
@@ -62,7 +62,7 @@ cat <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: pvc-reader-nginx-conf
   namespace: ${NAMESPACE}${OWNER_REFERENCE:+
   }${OWNER_REFERENCE}
 data:
@@ -168,7 +168,7 @@ spec:
         claimName: ${PVC_CLAIM_NAME}
     - name: conf
       configMap:
-        name: nginx-conf
+        name: pvc-reader-nginx-conf
         items:
           - key: nginx.conf
             path: nginx.conf


### PR DESCRIPTION
the config map name `nginx-conf` is also used by CNV in `openshift-cnv` namespace, which causes inability to fetch results if the checkup is being created at the `openshift-cnv` namespace. Renaming this config map name to `pvc-reader-nginx-conf` to avoid conflicts.