### PR TITLE
Fix false-positive test results when test suite fails during setup

### DIFF
--- a/junit_parser/junit/create_res_map.go
+++ b/junit_parser/junit/create_res_map.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -46,11 +48,20 @@ func NewResultMap(dir string) (map[string]TestSuite, error) {
 
 		go func(sig string) {
 			defer wg.Done()
+			exitCode := readExitCode(path.Join(dir, sig, ".exit_code"))
+
 			fileName := path.Join(dir, sig, junitFileName)
 			junitResult, err := readOneFile(fileName)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
+				if exitCode != 0 {
+					ch <- resultWithSig{sig: sig, junitResult: TestSuite{SetupFailure: true}}
+				}
 				return
+			}
+
+			if exitCode != 0 && junitResult.Failures == 0 && junitResult.Errors == 0 {
+				junitResult.SetupFailure = true
 			}
 
 			ch <- resultWithSig{sig: sig, junitResult: junitResult}
@@ -68,6 +79,18 @@ func NewResultMap(dir string) (map[string]TestSuite, error) {
 	}
 
 	return junitResults, nil
+}
+
+func readExitCode(filePath string) int {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return 0
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return code
 }
 
 func readOneFile(fileName string) (TestSuite, error) {

--- a/junit_parser/junit/types.go
+++ b/junit_parser/junit/types.go
@@ -19,6 +19,10 @@ type TestSuite struct {
 	Disabled  int        `xml:"disabled,attr"`
 	Time      float64    `xml:"time,attr"`
 	TestCases []TestCase `xml:"testcase"`
+
+	// SetupFailure is set when the test binary exited non-zero but JUnit
+	// reports zero failures, indicating a BeforeSuite or infrastructure error.
+	SetupFailure bool `xml:"-"`
 }
 
 type TestCase struct {

--- a/junit_parser/junit_parser.go
+++ b/junit_parser/junit_parser.go
@@ -28,6 +28,14 @@ func main() {
 	}
 
 	testRes := result.New(junitRes)
+
+	fmt.Print(testRes)
+
+	if testRes.SetupFailure && len(testRes.SigMap) == 0 {
+		fmt.Fprintln(os.Stderr, "Skipping ConfigMap creation: no tests were executed due to setup failure")
+		os.Exit(1)
+	}
+
 	resYaml, err := testRes.GetYaml()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get yaml: %v\n", err)
@@ -35,8 +43,6 @@ func main() {
 	}
 
 	cm, err := configmap.New(cfg, resYaml)
-
-	fmt.Print(testRes)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/result/result.go
+++ b/result/result.go
@@ -14,8 +14,9 @@ import (
 
 // Result represents the result of a test run, including a map of test suite results and a summary.
 type Result struct {
-	SigMap  SigMap  `json:",omitempty,inline"`
-	Summary Summary `json:"summary,omitempty"`
+	SigMap       SigMap  `json:",omitempty,inline"`
+	Summary      Summary `json:"summary,omitempty"`
+	SetupFailure bool    `json:"-"`
 }
 
 // New creates a new Result struct from the given map of JUnit test results.
@@ -25,6 +26,12 @@ func New(junitResults map[string]junit.TestSuite) Result {
 	}
 
 	for sig, testSuite := range junitResults {
+		if testSuite.SetupFailure {
+			res.SetupFailure = true
+			fmt.Fprintf(os.Stderr, "Suite %q failed during setup (no tests were executed)\n", sig)
+			continue
+		}
+
 		// Count skipped tests from testsuite header OR individual test cases
 		skipped := testSuite.Skipped + testSuite.Disabled
 
@@ -126,10 +133,12 @@ func (r Result) MarshalJSON() ([]byte, error) {
 	}
 
 	// Combine the two JSON objects
-	var resultJSON []byte
-	if len(sigMapJSON) > 0 {
-		resultJSON = append(sigMapJSON[:len(sigMapJSON)-1], ',')
+	if len(r.SigMap) == 0 {
+		return aliasJSON, nil
 	}
+
+	var resultJSON []byte
+	resultJSON = append(sigMapJSON[:len(sigMapJSON)-1], ',')
 	resultJSON = append(resultJSON, aliasJSON[1:]...) // Remove the opening brace from aliasJSON
 
 	return resultJSON, nil
@@ -138,6 +147,13 @@ func (r Result) MarshalJSON() ([]byte, error) {
 // String implements the Stringer interface for Result, to provide a human-readable summary of the test results.
 func (r Result) String() string {
 	sb := strings.Builder{}
+
+	if r.SetupFailure && len(r.SigMap) == 0 {
+		sb.WriteString("ERROR: No tests were executed. One or more test suites failed during setup.\n")
+		sb.WriteString("Check the test logs for details.\n")
+		return sb.String()
+	}
+
 	for sig, sigRes := range r.SigMap {
 		// Print summary for suite
 		header := "Summary for " + sig
@@ -161,6 +177,10 @@ func (r Result) String() string {
 				sb.WriteString(fmt.Sprintf("  - %s\n", testName))
 			}
 		}
+	}
+
+	if r.SetupFailure {
+		sb.WriteString("\nWARNING: Some test suites failed during setup and were not included in the summary above.\n")
 	}
 
 	header := fmt.Sprintf("Total Summary for execution from %s", os.Getenv("TIMESTAMP"))

--- a/result/results_test.go
+++ b/result/results_test.go
@@ -130,6 +130,61 @@ func TestMarshalsResultToJSONCorrectly(t *testing.T) {
 	}
 }
 
+func TestSetupFailureExcludesSuiteFromResults(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"compute": {
+			Tests:        63,
+			Failures:     0,
+			Errors:       0,
+			SetupFailure: true,
+		},
+	}
+
+	res := result.New(junitResults)
+
+	if !res.SetupFailure {
+		t.Error("expected SetupFailure to be true")
+	}
+	if len(res.SigMap) != 0 {
+		t.Errorf("expected 0 sigs (setup failure should be excluded), got %d", len(res.SigMap))
+	}
+	if res.Summary.Run != 0 {
+		t.Errorf("expected 0 total tests run, got %d", res.Summary.Run)
+	}
+}
+
+func TestSetupFailureWithOtherValidSuites(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"compute": {
+			Tests:        63,
+			Failures:     0,
+			SetupFailure: true,
+		},
+		"storage": {
+			Tests:    10,
+			Failures: 1,
+			TestCases: []junit.TestCase{
+				{Name: "test1", Failure: true},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+
+	if !res.SetupFailure {
+		t.Error("expected SetupFailure to be true")
+	}
+	if len(res.SigMap) != 1 {
+		t.Errorf("expected 1 sig (only storage), got %d", len(res.SigMap))
+	}
+	if _, ok := res.SigMap["storage"]; !ok {
+		t.Error("expected storage suite in results")
+	}
+	if res.Summary.Run != 10 {
+		t.Errorf("expected 10 total tests run, got %d", res.Summary.Run)
+	}
+}
+
 func TestConvertsResultToYAMLCorrectly(t *testing.T) {
 	junitResults := map[string]junit.TestSuite{
 		"sig1": {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -479,10 +479,16 @@ fi
 # =========
 # Summarize
 # =========
-junit_parser --results-dir=${RESULTS_DIR}  --start-timestamp=${START_TIMESTAMP} --completion-timestamp=${COMPLETION_TIMESTAMP} | tee ${RESULTS_DIR}/summary-log.txt
+PARSER_EXIT=0
+junit_parser --results-dir=${RESULTS_DIR}  --start-timestamp=${START_TIMESTAMP} --completion-timestamp=${COMPLETION_TIMESTAMP} | tee ${RESULTS_DIR}/summary-log.txt || PARSER_EXIT=$?
 
 # Archive test results into tar.gz (exclude .dry-run directory as a defensive measure)
 tar -czf /tmp/test-results-${TIMESTAMP}.tar.gz -C ${RESULTS_DIR} --exclude='.dry-run' .
 mv /tmp/test-results-${TIMESTAMP}.tar.gz ${RESULTS_DIR}/test-results-${TIMESTAMP}.tar.gz
+
+if [ ${PARSER_EXIT} -ne 0 ]; then
+  echo "Self Validation test run finished with errors (setup failure detected, no ConfigMap created)."
+  exit 1
+fi
 
 echo "Self Validation test run is done."

--- a/scripts/kubevirt/test-kubevirt.sh
+++ b/scripts/kubevirt/test-kubevirt.sh
@@ -207,7 +207,7 @@ if [ "${SIG}" == "storage" ] && [ -z "${DRY_RUN_FLAG}" ]; then
 fi
 
 echo "Starting ${SIG} tests 🧪"
-${TESTS_BINARY} \
+(set +e; ${TESTS_BINARY} \
     -cdi-namespace="$TARGET_NAMESPACE" \
     -config="${STORAGE_CONFIG_PATH}" \
     -installed-namespace="$TARGET_NAMESPACE" \
@@ -226,7 +226,7 @@ ${TESTS_BINARY} \
     -utility-container-tag="${KUBEVIRT_RELEASE}" \
     ${GINKGO_FLAKE} \
     ${DRY_RUN_FLAG} \
-    "${skip_arg}" 2>&1 | tee ${ARTIFACTS}/${SIG}-log.txt &
+    "${skip_arg}"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/${SIG}-log.txt &
 
 # Store the PID for cleanup
 TEST_PID=$!

--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -216,7 +216,7 @@ fi
 
 echo "Starting tier2 tests 🧪"
 
-./uv run pytest \
+(set +e; ./uv run pytest \
   -m "conformance" \
   -W "ignore::pytest.PytestRemovedIn9Warning" \
   --skip-artifactory-check \
@@ -231,7 +231,7 @@ echo "Starting tier2 tests 🧪"
   --data-collector \
   --data-collector-output-dir=${ARTIFACTS} \
   --pytest-log-file=${ARTIFACTS}/pytest-logs.txt \
-  --junitxml="${ARTIFACTS}/junit.results.xml" 2>&1 | tee ${ARTIFACTS}/tier2-log.txt &
+  --junitxml="${ARTIFACTS}/junit.results.xml"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/tier2-log.txt &
 
 # Store the PID for cleanup
 TEST_PID=$!


### PR DESCRIPTION
Cherry-pick of #62 to release-4.21.

When a test suite fails during setup (e.g. Ginkgo BeforeSuite failure or pytest early exit), the results summary incorrectly reports all tests as passed, and a ConfigMap is created with misleading data.

Root cause: the test binary's exit code is masked because its output is piped through `tee`, which always exits 0 regardless of the upstream command's status. Additionally, `set -e` in the test scripts is inherited by subshells, preventing the exit code capture from executing after a failure.

This commit fixes the issue across three layers:

1. **Exit code capture** (test-kubevirt.sh, test-tier2.sh): Wrap the test binary in a subshell with `set +e` to ensure the exit code is always written to an `.exit_code` file in the artifacts directory, even when the test binary fails.

2. **Setup failure detection** (junit_parser): After reading JUnit XML results for each suite, cross-reference with the `.exit_code` file. If the exit code is non-zero but JUnit reports zero failures, mark the suite as a setup failure and exclude it from the results summary. This also handles the case where no JUnit XML is produced at all (e.g. pytest exits before test collection).

3. **ConfigMap and summary handling** (entrypoint.sh, result.go): When all suites are setup failures, print a clear error message instead of a misleading "all passed" summary, skip ConfigMap creation, and exit with a non-zero status. When only some suites fail during setup, include a warning in the summary. A MarshalJSON bug that produced invalid JSON with an empty SigMap is also fixed.

**Conflict resolution**: The only conflict was in `test-tier2.sh` where `release-4.21` uses `./uv run pytest` while `main` uses `.venv/bin/pytest`. Resolved by keeping `./uv run pytest` and adding the `(set +e; ... ; echo $? > .exit_code)` wrapper.

Made with [Cursor](https://cursor.com)