### PR TITLE
CNV-78518: Rely on ITMS+IDMS instead of REGISTY_SERVER for disconnected envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,90 +237,11 @@ $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e DRY_RU
 ```
 
 ## Disconnected Environments
-The validation checkup can be run on disconnected (air-gapped) OpenShift clusters by using a mirror registry. This section explains how to configure the checkup for disconnected environments.
+The validation checkup can be run on disconnected (air-gapped) OpenShift clusters by mirroring the required test images to an accessible registry and configuring mirror sets (ITMS + IDMS). No changes to the checkup configuration are needed -- mirror sets transparently redirect image pulls at the CRI-O level.
 
-### Prerequisites for Disconnected Environments
-1. A mirror registry that contains all the required images
-2. The cluster must be configured to pull images from the mirror registry
+For full instructions, including which images to mirror, mirroring commands, mirror set configuration, and using the OpenShift internal registry, see the **[Disconnected Environments Guide](disconnected/README.md)**.
 
-### Using the REGISTRY_SERVER Parameter
-The `REGISTRY_SERVER` environment variable allows you to specify a custom mirror registry that replaces the default public registries (`registry.redhat.io`, `quay.io`, `ghcr.io`) used by the validation checkup.
-
-Example:
-```bash
-$ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e REGISTRY_SERVER=my-mirror-registry.example.com:5000 ${OCP_VIRT_VALIDATION_IMAGE} generate
-```
-
-This will configure the Job to use your mirror registry for all image pulls:
-```yaml
-apiVersion: batch/v1
-kind: Job
-spec:
-  template:
-    spec:
-      containers:
-        - name: ocp-virt-validation-checkup
-          env:
-            - name: REGISTRY_SERVER
-              value: my-mirror-registry.example.com:5000
-```
-
-When retrieving checkup results, you should also pass the `REGISTRY_SERVER` parameter so that the nginx pod used to serve results is pulled from your mirror registry:
-```bash
-$ podman run -e TIMESTAMP=${TIMESTAMP} -e REGISTRY_SERVER=my-mirror-registry.example.com:5000 ${OCP_VIRT_VALIDATION_IMAGE} get_results | oc apply -f -
-```
-
-### Mirror Registry Configuration
-The mirror registry server **must be configured to allow image pulls without authentication** from within the cluster. The validation checkup relies on unauthenticated access to pull images from the mirror registry during test execution.
-
-### Certificate Configuration
-The cluster must trust the mirror registry's TLS certificate to avoid `x509: certificate signed by unknown authority` errors.
-
-#### Option 1: Add the Registry Certificate to the Cluster (Recommended)
-Add your mirror registry's CA certificate to the cluster's trusted CA bundle:
-
-1. Create a ConfigMap containing the registry's CA certificate:
-```bash
-$ oc create configmap registry-ca \
-    --from-file=my-mirror-registry.example.com..5000=/path/to/ca-certificate.crt \
-    -n openshift-config
-```
-
-2. Update the cluster's image configuration to use the ConfigMap:
-```bash
-$ oc patch image.config.openshift.io/cluster --patch '{"spec":{"additionalTrustedCA":{"name":"registry-ca"}}}' --type=merge
-```
-
-#### Option 2: Configure the Registry as Insecure
-If you cannot add the certificate to the cluster, you can configure the registry as insecure. **This is not recommended for production environments.**
-
-Add your mirror registry to the `registrySources.insecureRegistries` list in the cluster's image configuration:
-```bash
-$ oc patch image.config.openshift.io/cluster --type=merge --patch '
-{
-  "spec": {
-    "registrySources": {
-      "insecureRegistries": [
-        "my-mirror-registry.example.com:5000"
-      ]
-    }
-  }
-}'
-```
-
-**Note:** After modifying the image configuration, the Machine Config Operator will roll out changes to all nodes. Wait for the rollout to complete before running the validation checkup:
-```bash
-$ oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
-```
-
-### Mirroring Required Images
-Ensure that all images used by the validation checkup are mirrored to your registry. The primary images that need to be mirrored include:
-- The OpenShift Virtualization related images (from `registry.redhat.io`)
-- KubeVirt utility container images (from `quay.io/kubevirt`)
-- The `astral-sh/uv` image (from `ghcr.io`) for tier2 tests
-- The nginx image `rhel9/nginx-124:latest` (from `registry.redhat.io`) for viewing detailed results
-
-You can use the `oc adm catalog mirror` or `oc image mirror` commands to mirror these images to your disconnected registry.
+A helper script at [`disconnected/mirror-images.sh`](disconnected/mirror-images.sh) automates the entire process.
 
 
 ## Retrieve Checkup Results

--- a/disconnected/README.md
+++ b/disconnected/README.md
@@ -1,0 +1,347 @@
+# Disconnected Environments
+
+The validation checkup can be run on disconnected (air-gapped) OpenShift clusters by using a mirror registry. This document explains how to configure the checkup for disconnected environments.
+
+## Prerequisites for Disconnected Environments
+1. A mirror registry accessible from the cluster (either an external registry or the OpenShift internal registry).
+2. All required test images mirrored to the registry (see [Mirroring Required Images](#mirroring-required-images)).
+3. Both an `ImageTagMirrorSet` (ITMS) and an `ImageDigestMirrorSet` (IDMS) configured to redirect image pulls from upstream registries to the mirror (see [Mirror Set Configuration](#mirror-set-configuration)).
+
+## How It Works
+The validation checkup references upstream image paths (e.g. `quay.io/kubevirt/...`). In disconnected environments, mirror sets transparently redirect these pulls to the mirror registry at the CRI-O level on each node. No changes to the checkup configuration or environment variables are needed.
+
+Two types of mirror sets are required because test images are referenced in two different ways:
+- **ITMS** (ImageTagMirrorSet): intercepts tag-based image references (e.g. `quay.io/kubevirt/alpine-container-disk-demo:v1.8.1`) used by the KubeVirt test suites (compute, network, storage).
+- **IDMS** (ImageDigestMirrorSet): intercepts digest-based image references (e.g. `quay.io/openshift-cnv/qe-net-utils@sha256:...`) used by the tier2 test suite.
+
+
+
+## Certificate Configuration
+If using an external mirror registry, the cluster must trust its TLS certificate.
+
+### Option 1: Add the Registry Certificate to the Cluster (Recommended)
+
+1. Create a ConfigMap containing the registry's CA certificate:
+```bash
+$ oc create configmap registry-ca \
+    --from-file=my-mirror-registry.example.com..5000=/path/to/ca-certificate.crt \
+    -n openshift-config
+```
+
+2. Update the cluster's image configuration to use the ConfigMap:
+```bash
+$ oc patch image.config.openshift.io/cluster --patch '{"spec":{"additionalTrustedCA":{"name":"registry-ca"}}}' --type=merge
+```
+
+### Option 2: Configure the Registry as Insecure
+**Not recommended for production environments.**
+
+```bash
+$ oc patch image.config.openshift.io/cluster --type=merge --patch '
+{
+  "spec": {
+    "registrySources": {
+      "insecureRegistries": [
+        "my-mirror-registry.example.com:5000"
+      ]
+    }
+  }
+}'
+```
+
+**Note:** After modifying the image configuration, the Machine Config Operator will roll out changes to all nodes. Wait for the rollout to complete:
+```bash
+$ oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+```
+
+## Mirroring Required Images
+
+The validation checkup uses several container images from public registries. In disconnected environments, all of these must be mirrored to an accessible registry.
+
+All mirroring should be performed from a bastion host (workstation) that has access to both the internet (to pull upstream images) and the disconnected cluster (to push images to the mirror registry).
+
+**Important:** When mirroring multi-architecture images (such as `qe-net-utils`), always use `--keep-manifest-list=true` with `oc image mirror`. Some test frameworks reference images by their manifest list digest rather than by tag. If only single-architecture manifests are pushed, digest-based pulls will fail with "manifest unknown".
+
+### KubeVirt Test Images (from `quay.io/kubevirt`)
+
+The KubeVirt test suites (compute, network, storage) use container disk images and utility containers from `quay.io/kubevirt`. The exact tag corresponds to the upstream KubeVirt version bundled with your OpenShift Virtualization release (e.g. `v1.8.1` for CNV 4.22).
+
+To determine the correct tag, extract the upstream version label from the `virt-operator` image:
+```bash
+$ VIRT_OPERATOR_IMAGE=$(oc get deployment virt-operator -n openshift-cnv -o jsonpath='{.spec.template.spec.containers[0].image}')
+$ KUBEVIRT_TAG=$(oc image info -a ~/pull-secret.json ${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq -r '.config.config.Labels["upstream-version"]')
+$ KUBEVIRT_RELEASE="v${KUBEVIRT_TAG%%-[0-9]*}"
+$ echo "KubeVirt release tag: ${KUBEVIRT_RELEASE}"
+```
+
+The `mirror-images.sh` helper script (see [Automated Mirroring Script](#automated-mirroring-script)) auto-detects this tag from the cluster. In disconnected environments where `oc image info` cannot reach the upstream registry, the script defaults to `v1.8.2`. Override with `--kubevirt-release` if your CNV version uses a different upstream KubeVirt release.
+
+The following images must be mirrored with the `${KUBEVIRT_RELEASE}` tag:
+
+| Image | Used by |
+|-------|---------|
+| `quay.io/kubevirt/cirros-container-disk-demo:${KUBEVIRT_RELEASE}` | Compute, Network, Storage tests - lightweight VM container disk |
+| `quay.io/kubevirt/alpine-container-disk-demo:${KUBEVIRT_RELEASE}` | Compute, Network tests - Alpine VM container disk |
+| `quay.io/kubevirt/fedora-with-test-tooling-container-disk:${KUBEVIRT_RELEASE}` | Storage, Network tests - Fedora VM with test tools |
+| `quay.io/kubevirt/alpine-with-test-tooling-container-disk:${KUBEVIRT_RELEASE}` | Storage tests - Alpine VM with test tools |
+| `quay.io/kubevirt/alpine-ext-kernel-boot-demo:${KUBEVIRT_RELEASE}` | Compute tests - kernel boot testing |
+| `quay.io/kubevirt/virtio-container-disk:${KUBEVIRT_RELEASE}` | Storage tests - VirtIO driver disk |
+| `quay.io/kubevirt/disks-images-provider:${KUBEVIRT_RELEASE}` | Storage tests - DaemonSet that pre-provisions disk images on nodes |
+| `quay.io/kubevirt/vm-killer:${KUBEVIRT_RELEASE}` | Storage export tests - download/utility pod |
+
+### Tier2 Test Images (from `quay.io/openshift-cnv`)
+
+The tier2 conformance tests (`openshift-virtualization-tests`) use the following images from `quay.io/openshift-cnv`:
+
+| Image | Used by |
+|-------|---------|
+| `quay.io/openshift-cnv/qe-cnv-tests-fedora:41` | Fedora VM container disk - used by most conformance tests that start a VM |
+| `quay.io/openshift-cnv/qe-net-utils:latest` | Network utility DaemonSet - used by network-related conformance tests. **Must be mirrored with `--keep-manifest-list=true`** because the test framework references it by digest. |
+
+For multi-architecture clusters, the following arch-specific Fedora images are also needed:
+
+| Image | Architecture |
+|-------|-------------|
+| `quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64` | ARM64 / aarch64 |
+| `quay.io/openshift-cnv/qe-cnv-tests-fedora:41-s390x` | s390x |
+
+### Other Required Images
+
+| Image | Used by |
+|-------|---------|
+| `registry.redhat.io/rhel9/nginx-124:latest` | Results viewer - nginx server for browsing test artifacts |
+
+### Mirroring Commands
+
+Mirror all required images to your registry. Use `oc image mirror` with `--keep-manifest-list=true` to preserve multi-architecture manifest lists:
+
+```bash
+MIRROR_REGISTRY="my-mirror-registry.example.com:5000"
+
+# Determine the KubeVirt release tag (see above)
+# KUBEVIRT_RELEASE=v1.8.1
+
+# --- KubeVirt test images ---
+KUBEVIRT_IMAGES=(
+  "cirros-container-disk-demo"
+  "alpine-container-disk-demo"
+  "fedora-with-test-tooling-container-disk"
+  "alpine-with-test-tooling-container-disk"
+  "alpine-ext-kernel-boot-demo"
+  "virtio-container-disk"
+  "disks-images-provider"
+  "vm-killer"
+)
+
+for img in "${KUBEVIRT_IMAGES[@]}"; do
+  echo "Mirroring quay.io/kubevirt/${img}:${KUBEVIRT_RELEASE} ..."
+  oc image mirror --keep-manifest-list=true \
+    "quay.io/kubevirt/${img}:${KUBEVIRT_RELEASE}" \
+    "${MIRROR_REGISTRY}/kubevirt/${img}:${KUBEVIRT_RELEASE}"
+done
+
+# --- Tier2 test images ---
+oc image mirror --keep-manifest-list=true \
+  "quay.io/openshift-cnv/qe-cnv-tests-fedora:41" \
+  "${MIRROR_REGISTRY}/openshift-cnv/qe-cnv-tests-fedora:41"
+
+oc image mirror --keep-manifest-list=true \
+  "quay.io/openshift-cnv/qe-net-utils:latest" \
+  "${MIRROR_REGISTRY}/openshift-cnv/qe-net-utils:latest"
+
+# --- Results viewer ---
+oc image mirror --keep-manifest-list=true \
+  "registry.redhat.io/rhel9/nginx-124:latest" \
+  "${MIRROR_REGISTRY}/rhel9/nginx-124:latest"
+```
+
+A helper script is provided at [`mirror-images.sh`](mirror-images.sh) that automates the mirroring process. See [Automated Mirroring Script](#automated-mirroring-script) below.
+
+## Mirror Set Configuration
+
+After mirroring the images, configure both an `ImageTagMirrorSet` (ITMS) and an `ImageDigestMirrorSet` (IDMS) so that the cluster redirects all image pulls to your mirror. Both are required:
+- **ITMS** handles tag-based references (used by KubeVirt test suites)
+- **IDMS** handles digest-based references (used by tier2 test suite)
+
+Create a file named `image-mirror-sets.yaml`:
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: ocp-virt-validation-mirrors
+spec:
+  imageTagMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - my-mirror-registry.example.com:5000/kubevirt
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - my-mirror-registry.example.com:5000/openshift-cnv
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - my-mirror-registry.example.com:5000/rhel9
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: ocp-virt-validation-digest-mirrors
+spec:
+  imageDigestMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - my-mirror-registry.example.com:5000/kubevirt
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - my-mirror-registry.example.com:5000/openshift-cnv
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - my-mirror-registry.example.com:5000/rhel9
+```
+
+Apply it:
+```bash
+$ oc apply -f image-mirror-sets.yaml
+```
+
+**Note:** After applying the mirror sets, the Machine Config Operator will roll out changes to all nodes. Wait for the rollout to complete:
+```bash
+$ oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+```
+
+## Using the OpenShift Internal Registry
+
+If you do not have an external mirror registry, you can use the OpenShift cluster's built-in image registry as the mirror target. The mirroring is performed from a bastion host (workstation) that has access to both the internet (to pull images) and the cluster (to push images).
+
+### Step 1: Expose the Internal Registry
+
+```bash
+$ oc patch configs.imageregistry.operator.openshift.io/cluster \
+    --type=merge --patch '{"spec":{"defaultRoute":true}}'
+```
+
+Get the registry hostname:
+```bash
+$ INTERNAL_REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+$ echo "Internal registry: ${INTERNAL_REGISTRY}"
+```
+
+### Step 2: Create the Mirror Namespace and Set Permissions
+
+```bash
+$ oc new-project kubevirt-mirror
+
+# Allow all cluster nodes to pull images from this namespace
+$ oc policy add-role-to-group system:image-puller system:authenticated -n kubevirt-mirror
+$ oc policy add-role-to-group system:image-puller system:unauthenticated -n kubevirt-mirror
+```
+
+### Step 3: Log in to the Internal Registry
+
+```bash
+$ oc whoami -t | podman login -u $(oc whoami) --password-stdin ${INTERNAL_REGISTRY} --tls-verify=false
+```
+
+**Note:** If `oc whoami` returns `system:admin` (certificate-based auth with no token), create a service account for pushing:
+```bash
+$ oc create sa registry-pusher -n kubevirt-mirror
+$ oc adm policy add-role-to-user system:image-builder -n kubevirt-mirror -z registry-pusher
+$ SA_TOKEN=$(oc create token registry-pusher -n kubevirt-mirror --duration=1h)
+$ echo "${SA_TOKEN}" | podman login -u unused --password-stdin ${INTERNAL_REGISTRY} --tls-verify=false
+```
+
+### Step 4: Mirror Images
+
+Use `oc image mirror` with `--keep-manifest-list=true` to preserve multi-architecture manifest lists. This is critical because some test images (e.g. `qe-net-utils`) are referenced by their manifest list digest:
+
+```bash
+# KUBEVIRT_RELEASE=v1.8.1  # Determine the correct tag (see above)
+
+IMAGES=(
+  "quay.io/kubevirt/cirros-container-disk-demo:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/alpine-container-disk-demo:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/fedora-with-test-tooling-container-disk:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/alpine-with-test-tooling-container-disk:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/alpine-ext-kernel-boot-demo:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/virtio-container-disk:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/disks-images-provider:${KUBEVIRT_RELEASE}"
+  "quay.io/kubevirt/vm-killer:${KUBEVIRT_RELEASE}"
+  "quay.io/openshift-cnv/qe-cnv-tests-fedora:41"
+  "quay.io/openshift-cnv/qe-net-utils:latest"
+  "registry.redhat.io/rhel9/nginx-124:latest"
+)
+
+for img in "${IMAGES[@]}"; do
+  img_name=$(echo "${img}" | sed 's|.*/||')
+  echo "Mirroring ${img} -> ${INTERNAL_REGISTRY}/kubevirt-mirror/${img_name}"
+  oc image mirror --keep-manifest-list=true --insecure=true \
+    "${img}" "${INTERNAL_REGISTRY}/kubevirt-mirror/${img_name}"
+done
+```
+
+### Step 5: Configure Mirror Sets for the Internal Registry
+
+The internal registry's in-cluster service name is `image-registry.openshift-image-registry.svc:5000`. Create both ITMS and IDMS:
+
+```yaml
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: ocp-virt-validation-mirrors
+spec:
+  imageTagMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: ocp-virt-validation-digest-mirrors
+spec:
+  imageDigestMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - image-registry.openshift-image-registry.svc:5000/kubevirt-mirror
+```
+
+```bash
+$ oc apply -f image-mirror-sets.yaml
+$ oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+```
+
+## Automated Mirroring Script
+
+A helper script at [`mirror-images.sh`](mirror-images.sh) automates the entire mirroring process. It supports both external mirror registries and the OpenShift internal registry, and handles authentication, manifest list preservation, and mirror set generation. Run it from a bastion host with access to both the internet and the cluster.
+
+Usage:
+```bash
+# Mirror to an external registry
+$ ./disconnected/mirror-images.sh --registry my-mirror-registry.example.com:5000
+
+# Mirror to the OpenShift internal registry
+$ ./disconnected/mirror-images.sh --use-internal-registry
+
+# Specify a custom KubeVirt release tag
+$ ./disconnected/mirror-images.sh --registry my-mirror-registry.example.com:5000 --kubevirt-release v1.8.1
+
+# Also generate and apply ITMS + IDMS
+$ ./disconnected/mirror-images.sh --registry my-mirror-registry.example.com:5000 --apply-mirror-set
+```
+
+The script will:
+1. Auto-detect the KubeVirt release tag from the cluster (if not provided)
+2. Mirror all required images with `--keep-manifest-list=true` to preserve multi-arch manifest lists
+3. When using `--use-internal-registry`, expose the internal registry route, create the mirror namespace, configure RBAC, and authenticate
+4. Optionally generate and apply both `ImageTagMirrorSet` and `ImageDigestMirrorSet`

--- a/disconnected/mirror-images.sh
+++ b/disconnected/mirror-images.sh
@@ -1,0 +1,424 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
+KUBEVIRT_RELEASE=""
+MIRROR_REGISTRY=""
+USE_INTERNAL_REGISTRY=false
+APPLY_MIRROR_SET=false
+PULL_SECRET="${PULL_SECRET:-}"
+TLS_VERIFY=true
+
+KUBEVIRT_IMAGES=(
+  "cirros-container-disk-demo"
+  "alpine-container-disk-demo"
+  "fedora-with-test-tooling-container-disk"
+  "alpine-with-test-tooling-container-disk"
+  "alpine-ext-kernel-boot-demo"
+  "virtio-container-disk"
+  "disks-images-provider"
+  "vm-killer"
+)
+
+TIER2_IMAGES=(
+  "quay.io/openshift-cnv/qe-cnv-tests-fedora:41"
+  "quay.io/openshift-cnv/qe-net-utils:latest"
+)
+
+OTHER_IMAGES=(
+  "registry.redhat.io/rhel9/nginx-124:latest"
+)
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Mirror all required images for the OCP Virt Validation Checkup to a
+disconnected registry.
+
+Options:
+  --registry REGISTRY          Target mirror registry (e.g. my-registry.example.com:5000)
+  --use-internal-registry      Use the OpenShift internal image registry as mirror target.
+                               Exposes the registry route, creates the namespace, and
+                               authenticates from the current workstation.
+  --kubevirt-release TAG       KubeVirt release tag (e.g. v1.8.1). Auto-detected if omitted.
+  --pull-secret FILE           Path to pull secret for registry authentication
+  --insecure                   Skip TLS verification for the mirror registry
+  --apply-mirror-set           Generate and apply ITMS + IDMS after mirroring
+  -h, --help                   Show this help message
+
+Examples:
+  # Mirror to external registry, auto-detect KubeVirt version
+  $(basename "$0") --registry my-registry.example.com:5000
+
+  # Mirror to the OpenShift internal registry
+  $(basename "$0") --use-internal-registry
+
+  # Mirror with specific version and apply mirror sets
+  $(basename "$0") --registry my-registry.example.com:5000 --kubevirt-release v1.8.1 --apply-mirror-set
+EOF
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --registry)       MIRROR_REGISTRY="$2"; shift 2 ;;
+    --use-internal-registry) USE_INTERNAL_REGISTRY=true; shift ;;
+    --kubevirt-release)      KUBEVIRT_RELEASE="$2"; shift 2 ;;
+    --pull-secret)    PULL_SECRET="$2"; shift 2 ;;
+    --insecure)       TLS_VERIFY=false; shift ;;
+    --apply-mirror-set)      APPLY_MIRROR_SET=true; shift ;;
+    -h|--help)        usage ;;
+    *)                echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+detect_kubevirt_release() {
+  echo "Auto-detecting KubeVirt release tag from cluster..."
+
+  local virt_operator_image
+  virt_operator_image=$(oc get deployment virt-operator -n openshift-cnv \
+    -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null) || true
+
+  if [ -z "${virt_operator_image}" ]; then
+    echo "Error: Could not find virt-operator deployment. Is OpenShift Virtualization installed?"
+    exit 1
+  fi
+
+  local pull_secret_arg=""
+  if [ -n "${PULL_SECRET}" ]; then
+    pull_secret_arg="-a ${PULL_SECRET}"
+  else
+    local tmp_secret
+    tmp_secret=$(mktemp)
+    oc get secret/pull-secret -n openshift-config \
+      -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > "${tmp_secret}"
+    pull_secret_arg="-a ${tmp_secret}"
+  fi
+
+  local insecure_flag=""
+  if [ "${TLS_VERIFY}" = false ]; then
+    insecure_flag="--insecure=true"
+  fi
+
+  local kubevirt_tag=""
+  kubevirt_tag=$(oc image info ${pull_secret_arg} ${insecure_flag} "${virt_operator_image}" \
+    -o json --filter-by-os=linux/amd64 2>/dev/null | \
+    jq -r '.config.config.Labels["upstream-version"] // empty') || true
+
+  if [ -z "${kubevirt_tag}" ]; then
+    kubevirt_tag=$(oc image info ${pull_secret_arg} ${insecure_flag} "brew.${virt_operator_image}" \
+      -o json --filter-by-os=linux/amd64 2>/dev/null | \
+      jq -r '.config.config.Labels["upstream-version"] // empty') || true
+  fi
+
+  if [ -z "${kubevirt_tag}" ]; then
+    local csv_version
+    csv_version=$(oc get csv -n openshift-cnv -o json | \
+      jq -r '.items[] | select(.metadata.name | startswith("kubevirt-hyperconverged")).spec.version') || true
+    if [ -n "${csv_version}" ]; then
+      local konflux_version="v$(echo "${csv_version}" | cut -d. -f1)-$(echo "${csv_version}" | cut -d. -f2)"
+      local image_name_with_digest
+      image_name_with_digest=$(echo "${virt_operator_image}" | sed 's|.*/||')
+      local konflux_image="quay.io/openshift-virtualization/konflux-builds/${konflux_version}/${image_name_with_digest}"
+      kubevirt_tag=$(oc image info ${pull_secret_arg} "${konflux_image}" \
+        -o json --filter-by-os=linux/amd64 2>/dev/null | \
+        jq -r '.config.config.Labels["upstream-version"] // empty') || true
+    fi
+  fi
+
+  if [ -z "${kubevirt_tag}" ]; then
+    KUBEVIRT_RELEASE="v1.8.2"
+    echo "WARNING: Could not auto-detect KubeVirt release tag. Using default: ${KUBEVIRT_RELEASE}"
+    echo "         Override with --kubevirt-release if needed."
+    return
+  fi
+
+  KUBEVIRT_RELEASE="v${kubevirt_tag%%-[0-9]*}"
+  echo "Detected KubeVirt release: ${KUBEVIRT_RELEASE}"
+}
+
+setup_internal_registry() {
+  echo "=== Setting up OpenShift internal registry ==="
+
+  local registry_config
+  registry_config=$(oc get configs.imageregistry.operator.openshift.io/cluster \
+    -o jsonpath='{.spec.defaultRoute}' 2>/dev/null) || true
+
+  if [ "${registry_config}" != "true" ]; then
+    echo "Exposing internal registry with default route..."
+    oc patch configs.imageregistry.operator.openshift.io/cluster \
+      --type=merge --patch '{"spec":{"defaultRoute":true}}'
+    echo "Waiting for route to be available..."
+    sleep 10
+  fi
+
+  MIRROR_REGISTRY=$(oc get route default-route -n openshift-image-registry \
+    -o jsonpath='{.spec.host}')
+  echo "Internal registry route: ${MIRROR_REGISTRY}"
+
+  if ! oc get project kubevirt-mirror &>/dev/null; then
+    echo "Creating kubevirt-mirror namespace..."
+    oc new-project kubevirt-mirror
+  fi
+
+  echo "Configuring RBAC permissions..."
+  oc policy add-role-to-group system:image-puller system:authenticated -n kubevirt-mirror 2>/dev/null || true
+  oc policy add-role-to-group system:image-puller system:unauthenticated -n kubevirt-mirror 2>/dev/null || true
+
+  echo "Authenticating to internal registry..."
+  local login_user
+  local login_token
+  login_user=$(oc whoami 2>/dev/null) || true
+
+  if [ "${login_user}" = "system:admin" ]; then
+    echo "  system:admin uses certificates, creating a service account for push access..."
+    oc create sa registry-pusher -n kubevirt-mirror 2>/dev/null || true
+    oc adm policy add-role-to-user system:image-builder -n kubevirt-mirror -z registry-pusher 2>/dev/null || true
+    login_token=$(oc create token registry-pusher -n kubevirt-mirror --duration=1h)
+    login_user="unused"
+  else
+    login_token=$(oc whoami -t)
+  fi
+
+  echo "${login_token}" | podman login -u "${login_user}" --password-stdin "${MIRROR_REGISTRY}" \
+    --tls-verify=false
+
+  TLS_VERIFY=false
+}
+
+get_mirror_flags() {
+  local flags=""
+  if [ "${TLS_VERIFY}" = false ]; then
+    flags+="--insecure=true "
+  fi
+  if [ -n "${PULL_SECRET}" ]; then
+    flags+="-a ${PULL_SECRET} "
+  fi
+  echo "${flags}"
+}
+
+mirror_kubevirt_images() {
+  echo ""
+  echo "=== Mirroring KubeVirt test images (tag: ${KUBEVIRT_RELEASE}) ==="
+
+  local target_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    target_prefix="${MIRROR_REGISTRY}/kubevirt-mirror"
+  else
+    target_prefix="${MIRROR_REGISTRY}/kubevirt"
+  fi
+
+  local flags
+  flags=$(get_mirror_flags)
+
+  local failed=()
+  for img in "${KUBEVIRT_IMAGES[@]}"; do
+    local source="quay.io/kubevirt/${img}:${KUBEVIRT_RELEASE}"
+    local target="${target_prefix}/${img}:${KUBEVIRT_RELEASE}"
+    echo ""
+    echo "  ${source}"
+    echo "  -> ${target}"
+
+    if oc image mirror --keep-manifest-list=true ${flags} \
+      "${source}" "${target}" 2>&1; then
+      echo "  OK"
+    else
+      echo "  FAILED"
+      failed+=("${img}")
+    fi
+  done
+
+  if [ ${#failed[@]} -gt 0 ]; then
+    echo ""
+    echo "WARNING: Failed to mirror ${#failed[@]} image(s): ${failed[*]}"
+  fi
+}
+
+mirror_tier2_images() {
+  echo ""
+  echo "=== Mirroring tier2 test images ==="
+
+  local target_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    target_prefix="${MIRROR_REGISTRY}/kubevirt-mirror"
+  else
+    target_prefix="${MIRROR_REGISTRY}/openshift-cnv"
+  fi
+
+  local flags
+  flags=$(get_mirror_flags)
+
+  local failed=()
+  for full_image in "${TIER2_IMAGES[@]}"; do
+    local image_name_tag
+    image_name_tag=$(echo "${full_image}" | sed 's|.*/||')
+
+    local target="${target_prefix}/${image_name_tag}"
+    echo ""
+    echo "  ${full_image}"
+    echo "  -> ${target}"
+
+    if oc image mirror --keep-manifest-list=true ${flags} \
+      "${full_image}" "${target}" 2>&1; then
+      echo "  OK"
+    else
+      echo "  FAILED"
+      failed+=("${image_name_tag}")
+    fi
+  done
+
+  if [ ${#failed[@]} -gt 0 ]; then
+    echo ""
+    echo "WARNING: Failed to mirror ${#failed[@]} tier2 image(s): ${failed[*]}"
+  fi
+}
+
+mirror_other_images() {
+  echo ""
+  echo "=== Mirroring additional images ==="
+
+  local target_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    target_prefix="${MIRROR_REGISTRY}/kubevirt-mirror"
+  else
+    target_prefix="${MIRROR_REGISTRY}"
+  fi
+
+  local flags
+  flags=$(get_mirror_flags)
+
+  for full_image in "${OTHER_IMAGES[@]}"; do
+    local image_name
+    image_name=$(echo "${full_image}" | sed 's|.*/||')
+
+    local target="${target_prefix}/${image_name}"
+    echo ""
+    echo "  ${full_image}"
+    echo "  -> ${target}"
+
+    if oc image mirror --keep-manifest-list=true ${flags} \
+      "${full_image}" "${target}" 2>&1; then
+      echo "  OK"
+    else
+      echo "  FAILED (image may require authentication - check pull secret)"
+    fi
+  done
+}
+
+generate_mirror_set() {
+  local mirror_set_file
+  mirror_set_file=$(mktemp --suffix=.yaml)
+
+  local target_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    target_prefix="image-registry.openshift-image-registry.svc:5000/kubevirt-mirror"
+  else
+    target_prefix="${MIRROR_REGISTRY}/kubevirt"
+  fi
+
+  local tier2_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    tier2_prefix="image-registry.openshift-image-registry.svc:5000/kubevirt-mirror"
+  else
+    tier2_prefix="${MIRROR_REGISTRY}/openshift-cnv"
+  fi
+
+  local other_prefix
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    other_prefix="image-registry.openshift-image-registry.svc:5000/kubevirt-mirror"
+  else
+    other_prefix="${MIRROR_REGISTRY}"
+  fi
+
+  cat > "${mirror_set_file}" <<EOF
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: ocp-virt-validation-mirrors
+spec:
+  imageTagMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - ${target_prefix}
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - ${tier2_prefix}
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - ${other_prefix}
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: ocp-virt-validation-digest-mirrors
+spec:
+  imageDigestMirrors:
+    - source: quay.io/kubevirt
+      mirrors:
+        - ${target_prefix}
+    - source: quay.io/openshift-cnv
+      mirrors:
+        - ${tier2_prefix}
+    - source: registry.redhat.io/rhel9
+      mirrors:
+        - ${other_prefix}
+EOF
+
+  echo ""
+  echo "=== Generated Mirror Sets (ITMS + IDMS) ==="
+  cat "${mirror_set_file}"
+
+  if [ "${APPLY_MIRROR_SET}" = true ]; then
+    echo ""
+    echo "Applying mirror sets..."
+    oc apply -f "${mirror_set_file}"
+    echo ""
+    echo "Waiting for MachineConfigPools to update (this may take several minutes)..."
+    oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+    echo "MachineConfigPools updated."
+  else
+    echo ""
+    echo "To apply these mirror sets, run:"
+    echo "  oc apply -f ${mirror_set_file}"
+    echo "  oc wait machineconfigpool --all --for=condition=Updated --timeout=30m"
+  fi
+}
+
+# --- Main ---
+
+if [ "${USE_INTERNAL_REGISTRY}" = false ] && [ -z "${MIRROR_REGISTRY}" ]; then
+  echo "Error: Either --registry or --use-internal-registry is required."
+  echo ""
+  usage
+fi
+
+if [ -z "${KUBEVIRT_RELEASE}" ]; then
+  detect_kubevirt_release
+else
+  echo "Using provided KubeVirt release: ${KUBEVIRT_RELEASE}"
+fi
+
+if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+  setup_internal_registry
+fi
+
+mirror_kubevirt_images
+mirror_tier2_images
+mirror_other_images
+
+generate_mirror_set
+
+echo ""
+echo "=== Mirroring complete ==="
+echo ""
+echo "Next steps:"
+if [ "${APPLY_MIRROR_SET}" = false ]; then
+  echo "  1. Apply the mirror sets (ITMS + IDMS) - see above"
+  echo "  2. Wait for MachineConfigPools to update"
+fi
+echo "  - Run the validation checkup as usual (mirror sets handle image redirection transparently):"
+echo "    podman run -e OCP_VIRT_VALIDATION_IMAGE=\${OCP_VIRT_VALIDATION_IMAGE} \\"
+echo "      \${OCP_VIRT_VALIDATION_IMAGE} generate | oc apply -f -"

--- a/manifests/fetch/get_results.sh
+++ b/manifests/fetch/get_results.sh
@@ -20,13 +20,7 @@ else
   PVC_CLAIM_NAME="ocp-virt-validation-pvc-${TIMESTAMP}"
 fi
 
-# Determine nginx image: use REGISTRY_SERVER if provided, otherwise use default
-NGINX_IMAGE_PATH="rhel9/nginx-124:latest"
-if [ -n "${REGISTRY_SERVER}" ]; then
-  NGINX_IMAGE="${REGISTRY_SERVER}/${NGINX_IMAGE_PATH}"
-else
-  NGINX_IMAGE="registry.redhat.io/${NGINX_IMAGE_PATH}"
-fi
+NGINX_IMAGE="registry.redhat.io/rhel9/nginx-124:latest"
 
 # Get job name and UID from the ConfigMap's owner reference
 # The ConfigMap should already have the job as its owner

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -40,7 +40,6 @@ fi
 
 
 TEST_SKIPS=${TEST_SKIPS:-""}
-REGISTRY_SERVER=${REGISTRY_SERVER:-""}
 
 VALID_SKIP_REGEX='^([a-zA-Z0-9_:|-]+)(\|([a-zA-Z0-9_:|-]+))*$'
 if [[ -n "${TEST_SKIPS}" && ! "${TEST_SKIPS}" =~ ${VALID_SKIP_REGEX} ]]; then
@@ -196,8 +195,6 @@ spec:
               value: ${STORAGE_CLASS}
             - name: STORAGE_CAPABILITIES
               value: ${STORAGE_CAPABILITIES}
-            - name: REGISTRY_SERVER
-              value: ${REGISTRY_SERVER}
           volumeMounts:
             - name: results-volume
               mountPath: /results

--- a/progress_watcher/progress_watcher.go
+++ b/progress_watcher/progress_watcher.go
@@ -530,9 +530,6 @@ func runDryRunForSuite(suiteName, resultsDir string) int {
 	if storageClass := os.Getenv("STORAGE_CLASS"); storageClass != "" {
 		env = append(env, fmt.Sprintf("STORAGE_CLASS=%s", storageClass))
 	}
-	if registryServer := os.Getenv("REGISTRY_SERVER"); registryServer != "" {
-		env = append(env, fmt.Sprintf("REGISTRY_SERVER=%s", registryServer))
-	}
 	if fullSuite := os.Getenv("FULL_SUITE"); fullSuite != "" {
 		env = append(env, fmt.Sprintf("FULL_SUITE=%s", fullSuite))
 	}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -146,23 +146,9 @@ oc get secret/pull-secret -n openshift-config -o jsonpath='{.data.\.dockerconfig
 export REGISTRY_CONFIG
 VIRT_OPERATOR_IMAGE=$(oc get deployment virt-operator -n openshift-cnv -o jsonpath='{.spec.template.spec.containers[0].image}')
 
-# Replace registry server if REGISTRY_SERVER is provided
 INSECURE_FLAG=""
-if [ -n "${REGISTRY_SERVER}" ]; then
-  echo "Replacing registry server with: ${REGISTRY_SERVER}"
-  # Extract the image path after the registry (everything after the first '/')
-  # This handles both registry.redhat.io/path/to/image and registry.redhat.io:port/path/to/image
-  IMAGE_PATH=$(echo "${VIRT_OPERATOR_IMAGE}" | sed 's|^[^/]*/||')
-  VIRT_OPERATOR_IMAGE="${REGISTRY_SERVER}/${IMAGE_PATH}"
-  echo "Using virt-operator image: ${VIRT_OPERATOR_IMAGE}"
-  INSECURE_FLAG="--insecure=true"
-fi
 
 KUBEVIRT_TAG=$(oc image info -a ${REGISTRY_CONFIG} ${INSECURE_FLAG} ${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq -r '.config.config.Labels["upstream-version"]')
-if [ -z "${KUBEVIRT_TAG}" ]
-then
-  KUBEVIRT_TAG=$(oc image info -a ${REGISTRY_CONFIG} ${INSECURE_FLAG} brew.${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq -r '.config.config.Labels["upstream-version"]')
-fi
 if [ -z "${KUBEVIRT_TAG}" ]
 then
   # Try quay.io/openshift-virtualization/konflux-builds path as fallback
@@ -179,10 +165,11 @@ then
 fi
 if [ -z "${KUBEVIRT_TAG}" ]
 then
-  echo "Error: could not get kubevirt tag from virt-operator image."
-  exit 1
+  export KUBEVIRT_RELEASE="v1.8.2"
+  echo "WARNING: Could not auto-detect KubeVirt release tag. Using default: ${KUBEVIRT_RELEASE}"
+else
+  export KUBEVIRT_RELEASE="v${KUBEVIRT_TAG%%-[0-9]*}"
 fi
-export KUBEVIRT_RELEASE="v${KUBEVIRT_TAG%%-[0-9]*}"
 
 mkdir -p ${RESULTS_DIR}
 START_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/scripts/kubevirt/test-kubevirt.sh
+++ b/scripts/kubevirt/test-kubevirt.sh
@@ -21,13 +21,9 @@ function apply_disk_images_provider() {
         return 0
     fi
     
-    echo "Applying disk-images-provider with KUBEVIRT_RELEASE=${KUBEVIRT_RELEASE}, REGISTRY_SERVER=${REGISTRY_SERVER}"
+    echo "Applying disk-images-provider with KUBEVIRT_RELEASE=${KUBEVIRT_RELEASE}"
     
-    # Replace the image tag with KUBEVIRT_RELEASE and optionally registry with REGISTRY_SERVER, then apply
     local sed_args=(-e "s|__KUBEVIRT_RELEASE__|${KUBEVIRT_RELEASE}|g")
-    if [ "${REGISTRY_SERVER}" != "quay.io" ]; then
-        sed_args+=(-e "s|quay.io|${REGISTRY_SERVER}|g")
-    fi
     sed "${sed_args[@]}" "${yaml_file}" | oc apply -f -
     
     if [ $? -eq 0 ]; then
@@ -50,9 +46,6 @@ function cleanup_disk_images_provider() {
         if [ -f "${yaml_file}" ]; then
             # Use the same substitution and delete
             local sed_args=(-e "s|__KUBEVIRT_RELEASE__|${KUBEVIRT_RELEASE}|g")
-            if [ "${REGISTRY_SERVER}" != "quay.io" ]; then
-                sed_args+=(-e "s|quay.io|${REGISTRY_SERVER}|g")
-            fi
             sed "${sed_args[@]}" "${yaml_file}" | oc delete -f - --ignore-not-found=true
             echo "disk-images-provider resources deleted"
         fi
@@ -90,9 +83,6 @@ function cleanup_and_exit() {
 
 readonly SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 readonly TARGET_NAMESPACE="openshift-cnv"
-
-# Set default registry server if not provided
-REGISTRY_SERVER="${REGISTRY_SERVER:-quay.io}"
 
 # Set up signal traps for cleanup EARLY
 trap cleanup_and_exit SIGINT SIGTERM
@@ -222,7 +212,7 @@ echo "Starting ${SIG} tests 🧪"
     -kubectl-path=/usr/bin/oc \
     -virtctl-path=/home/ocp-virt-validation-checkup/virtctl \
     -kubeconfig ${SCRIPT_DIR}/../../kubeconfig \
-    -utility-container-prefix="${REGISTRY_SERVER}/kubevirt" \
+    -utility-container-prefix="quay.io/kubevirt" \
     -utility-container-tag="${KUBEVIRT_RELEASE}" \
     ${GINKGO_FLAKE} \
     ${DRY_RUN_FLAG} \

--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -34,18 +34,6 @@ trap cleanup_and_exit SIGINT SIGTERM
 
 cd /openshift-virtualization-tests
 
-# Set default registry server if not provided
-REGISTRY_SERVER="${REGISTRY_SERVER:-ghcr.io}"
-
-INSECURE_FLAG=""
-REGISTRY_AUTH=""
-if [ -n "${REGISTRY_SERVER}" ] && [ "${REGISTRY_SERVER}" != "ghcr.io" ]; then
-    INSECURE_FLAG="--insecure=true"
-    if [ -n "${REGISTRY_CONFIG}" ]; then
-        REGISTRY_AUTH="-a ${REGISTRY_CONFIG}"
-    fi
-fi
-
 export ARTIFACTS=${RESULTS_DIR}/tier2
 mkdir -p "${ARTIFACTS}"
 
@@ -173,18 +161,6 @@ else
 fi
 
 export OPENSHIFT_PYTHON_WRAPPER_LOG_FILE=${ARTIFACTS}/ocp-wrapper-log.txt
-
-# Replace quay.io with custom registry and add --insecure=true to oc image commands in disconnected environments
-if [ -n "${REGISTRY_SERVER}" ] && [ "${REGISTRY_SERVER}" != "ghcr.io" ]; then
-    echo "Replacing quay.io with ${REGISTRY_SERVER} in test code..."
-    find /openshift-virtualization-tests -type f \( -name "*.py" -o -name "*.yaml" -o -name "*.yml" \) \
-        -exec sed -i "s|quay.io|${REGISTRY_SERVER}|g" {} + 2>/dev/null || true
-    
-    echo "Adding --insecure=true to oc image commands..."
-    find /openshift-virtualization-tests -type f \( -name "*.py" -o -name "*.sh" \) \
-        -exec sed -i 's/oc image /oc image --insecure=true /g' {} + 2>/dev/null || true
-    echo "Registry replacement complete"
-fi
 
 grep -A 3 "oc image" utilities/virt.py
 


### PR DESCRIPTION
Move disconnected environment documentation and mirroring script into a dedicated disconnected/ folder. The main README now links to the full guide instead of inlining the entire section.

Remove all REGISTRY_SERVER references from the codebase. Image redirection in disconnected environments is now handled transparently by ImageTagMirrorSet (ITMS) and ImageDigestMirrorSet (IDMS), which operate at the CRI-O level on each node. This eliminates the need for runtime registry substitution in test scripts.

The mirroring script (disconnected/mirror-images.sh) supports both external mirror registries and the OpenShift internal registry, runs from a bastion host, preserves multi-arch manifest lists, and generates both ITMS and IDMS configurations.

When KUBEVIRT_RELEASE cannot be auto-detected from the virt-operator image (e.g. in disconnected clusters), it now defaults to v1.8.2 instead of failing.