### PR TITLE
CNV-75331: Add `TEST_FOCUS` parameter for selective test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e TEST_S
 ```
 **Note:** the value passed to `TEST_SKIPS` should be pipe-separated.
 
+#### Test Focus
+In order to run only specific test cases, a `TEST_FOCUS` environment variable can be specified. Only tests matching the provided patterns will be executed.
+Example:
+```bash
+$ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e TEST_FOCUS="test_id:1618|test_id:1783" ${OCP_VIRT_VALIDATION_IMAGE} generate
+```
+**Note:** the value passed to `TEST_FOCUS` should be pipe-separated, same as `TEST_SKIPS`.
+
+If the same test appears in both `TEST_FOCUS` and `TEST_SKIPS`, a warning is printed and the test **will run** (`TEST_FOCUS` takes precedence).
+
 #### Full Suite
 By default, only a small, representative and most robust test cases are selected to run.  
 In order to run all of the available tests, without filtering only to the conformance ones, the ` FULL_SUITE` environment variable can be set to `true`.  

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -40,12 +40,31 @@ fi
 
 
 TEST_SKIPS=${TEST_SKIPS:-""}
+TEST_FOCUS=${TEST_FOCUS:-""}
 
-VALID_SKIP_REGEX='^([a-zA-Z0-9_:|-]+)(\|([a-zA-Z0-9_:|-]+))*$'
-if [[ -n "${TEST_SKIPS}" && ! "${TEST_SKIPS}" =~ ${VALID_SKIP_REGEX} ]]; then
+VALID_FILTER_REGEX='^([^|]+)(\|([^|]+))*$'
+if [[ -n "${TEST_SKIPS}" && ! "${TEST_SKIPS}" =~ ${VALID_FILTER_REGEX} ]]; then
   echo "Invalid TEST_SKIPS format: \"${TEST_SKIPS}\""
   echo "Expected: pipe-separated list of test cases"
   exit 1
+fi
+
+if [[ -n "${TEST_FOCUS}" && ! "${TEST_FOCUS}" =~ ${VALID_FILTER_REGEX} ]]; then
+  echo "Invalid TEST_FOCUS format: \"${TEST_FOCUS}\""
+  echo "Expected: pipe-separated list of test cases"
+  exit 1
+fi
+
+if [[ -n "${TEST_FOCUS}" && -n "${TEST_SKIPS}" ]]; then
+  IFS='|' read -ra focus_entries <<< "${TEST_FOCUS}"
+  IFS='|' read -ra skip_entries <<< "${TEST_SKIPS}"
+  for f in "${focus_entries[@]}"; do
+    for s in "${skip_entries[@]}"; do
+      if [[ "${f}" == "${s}" ]]; then
+        echo "WARNING: '${f}' appears in both TEST_FOCUS and TEST_SKIPS. TEST_FOCUS takes precedence; test will run."
+      fi
+    done
+  done
 fi
 
 # Validate STORAGE_CAPABILITIES if provided
@@ -189,6 +208,8 @@ spec:
               value: ${TEST_SUITES}
             - name: TEST_SKIPS
               value: ${TEST_SKIPS}
+            - name: TEST_FOCUS
+              value: ${TEST_FOCUS}
             - name: FULL_SUITE
               value: "${FULL_SUITE}"
             - name: STORAGE_CLASS

--- a/progress_watcher/progress_watcher.go
+++ b/progress_watcher/progress_watcher.go
@@ -544,6 +544,9 @@ func runDryRunForSuite(suiteName, resultsDir string) int {
 	if testSkips := os.Getenv("TEST_SKIPS"); testSkips != "" {
 		env = append(env, fmt.Sprintf("TEST_SKIPS=%s", testSkips))
 	}
+	if testFocus := os.Getenv("TEST_FOCUS"); testFocus != "" {
+		env = append(env, fmt.Sprintf("TEST_FOCUS=%s", testFocus))
+	}
 
 	// Add suite-specific environment variables
 	if suiteName == "tier2" {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -217,11 +217,29 @@ if [[ ! "$TEST_SUITES" =~ ^($ALLOWED_TEST_SUITES)(,($ALLOWED_TEST_SUITES))*$ ]];
 fi
 
 
-VALID_SKIP_REGEX='^([a-zA-Z0-9_:|-]+)(\|([a-zA-Z0-9_:|-]+))*$'
-if [[ -n "${TEST_SKIPS}" && ! "${TEST_SKIPS}" =~ ${VALID_SKIP_REGEX} ]]; then
+VALID_FILTER_REGEX='^([^|]+)(\|([^|]+))*$'
+if [[ -n "${TEST_SKIPS}" && ! "${TEST_SKIPS}" =~ ${VALID_FILTER_REGEX} ]]; then
   echo "Invalid TEST_SKIPS format: \"${TEST_SKIPS}\""
   echo "Expected: pipe-separated list of test cases"
   exit 1
+fi
+
+if [[ -n "${TEST_FOCUS}" && ! "${TEST_FOCUS}" =~ ${VALID_FILTER_REGEX} ]]; then
+  echo "Invalid TEST_FOCUS format: \"${TEST_FOCUS}\""
+  echo "Expected: pipe-separated list of test cases"
+  exit 1
+fi
+
+if [[ -n "${TEST_FOCUS}" && -n "${TEST_SKIPS}" ]]; then
+  IFS='|' read -ra focus_entries <<< "${TEST_FOCUS}"
+  IFS='|' read -ra skip_entries <<< "${TEST_SKIPS}"
+  for f in "${focus_entries[@]}"; do
+    for s in "${skip_entries[@]}"; do
+      if [[ "${f}" == "${s}" ]]; then
+        echo "WARNING: '${f}' appears in both TEST_FOCUS and TEST_SKIPS. TEST_FOCUS takes precedence; test will run."
+      fi
+    done
+  done
 fi
 
 IFS=',' read -ra SUITES <<< "$TEST_SUITES"

--- a/scripts/kubevirt/test-kubevirt.sh
+++ b/scripts/kubevirt/test-kubevirt.sh
@@ -109,6 +109,29 @@ for ginkgo_label_name in $(jq -r '.[].ginkgo_label_name' $skip_tests_labels_file
   label_filter+=( "!($ginkgo_label_name)" )
 done
 
+# If TEST_FOCUS is set, remove any overlapping entries from skip list so focused tests run
+if [ -n "${TEST_FOCUS}" ]; then
+  IFS='|' read -ra focus_entries <<< "${TEST_FOCUS}"
+  filtered_skip_tests=()
+  for skip in "${skip_tests[@]}"; do
+    dominated=false
+    for f in "${focus_entries[@]}"; do
+      if [[ "${skip}" == "${f}" ]]; then
+        echo "WARNING: '${f}' is in both TEST_FOCUS and TEST_SKIPS. Removing from skip list so it will run."
+        dominated=true
+        break
+      fi
+    done
+    if [ "${dominated}" = false ]; then
+      filtered_skip_tests+=("${skip}")
+    fi
+  done
+  skip_tests=("${filtered_skip_tests[@]}")
+
+  focus_regex=$(printf '(%s)|' "${focus_entries[@]}")
+  ginkgo_focus=$(printf -- '--ginkgo.focus=%s' "${focus_regex:0:-1}")
+fi
+
 skip_regex=$(printf '(%s)|' "${skip_tests[@]}")
 skip_arg=$(printf -- '--ginkgo.skip=%s' "${skip_regex:0:-1}")
 

--- a/scripts/ssp/test-ssp.sh
+++ b/scripts/ssp/test-ssp.sh
@@ -12,6 +12,29 @@ if [ -n "${TEST_SKIPS}" ]; then
   skip_tests+=("${TEST_SKIPS}")
 fi
 
+ginkgo_focus=""
+if [ -n "${TEST_FOCUS}" ]; then
+  IFS='|' read -ra focus_entries <<< "${TEST_FOCUS}"
+  filtered_skip_tests=()
+  for skip in "${skip_tests[@]}"; do
+    dominated=false
+    for f in "${focus_entries[@]}"; do
+      if [[ "${skip}" == "${f}" ]]; then
+        echo "WARNING: '${f}' is in both TEST_FOCUS and TEST_SKIPS. Removing from skip list so it will run."
+        dominated=true
+        break
+      fi
+    done
+    if [ "${dominated}" = false ]; then
+      filtered_skip_tests+=("${skip}")
+    fi
+  done
+  skip_tests=("${filtered_skip_tests[@]}")
+
+  focus_regex=$(printf '(%s)|' "${focus_entries[@]}")
+  ginkgo_focus=$(printf -- '--ginkgo.focus=%s' "${focus_regex:0:-1}")
+fi
+
 skip_regex=$(printf '(%s)|' "${skip_tests[@]}")
 skip_arg=$(printf -- '--ginkgo.skip=%s' "${skip_regex:0:-1}")
 
@@ -57,6 +80,7 @@ ${SSP_TESTS_BINARY} \
   --ginkgo.junit-report="${ARTIFACTS}/junit.results.xml" \
   --ginkgo.skip='\[QUARANTINE\]' \
   ${label_filter} \
+  ${ginkgo_focus} \
   --ginkgo.v \
   --ginkgo.no-color \
   ${DRY_RUN_FLAG} \

--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -164,9 +164,42 @@ export OPENSHIFT_PYTHON_WRAPPER_LOG_FILE=${ARTIFACTS}/ocp-wrapper-log.txt
 
 grep -A 3 "oc image" utilities/virt.py
 
-SKIP_ARGS=()
-if [ -n "${TEST_SKIPS}" ]; then
-  SKIP_ARGS=(-k "not ($(echo "${TEST_SKIPS}" | sed 's/|/ or /g'))")
+K_EXPR=""
+
+if [ -n "${TEST_FOCUS}" ] && [ -n "${TEST_SKIPS}" ]; then
+  IFS='|' read -ra focus_entries <<< "${TEST_FOCUS}"
+  IFS='|' read -ra skip_entries <<< "${TEST_SKIPS}"
+  filtered_skips=()
+  for s in "${skip_entries[@]}"; do
+    overlap=false
+    for f in "${focus_entries[@]}"; do
+      if [[ "${s}" == "${f}" ]]; then
+        echo "WARNING: '${f}' is in both TEST_FOCUS and TEST_SKIPS. TEST_FOCUS takes precedence; test will run."
+        overlap=true
+        break
+      fi
+    done
+    if [ "${overlap}" = false ]; then
+      filtered_skips+=("${s}")
+    fi
+  done
+
+  focus_expr="$(echo "${TEST_FOCUS}" | sed 's/|/ or /g')"
+  if [ ${#filtered_skips[@]} -gt 0 ]; then
+    skip_expr="$(IFS='|'; echo "${filtered_skips[*]}" | sed 's/|/ or /g')"
+    K_EXPR="(${focus_expr}) and not (${skip_expr})"
+  else
+    K_EXPR="${focus_expr}"
+  fi
+elif [ -n "${TEST_FOCUS}" ]; then
+  K_EXPR="$(echo "${TEST_FOCUS}" | sed 's/|/ or /g')"
+elif [ -n "${TEST_SKIPS}" ]; then
+  K_EXPR="not ($(echo "${TEST_SKIPS}" | sed 's/|/ or /g'))"
+fi
+
+K_ARGS=()
+if [ -n "${K_EXPR}" ]; then
+  K_ARGS=(-k "${K_EXPR}")
 fi
 
 echo "Starting tier2 tests 🧪"
@@ -182,7 +215,7 @@ echo "Starting tier2 tests 🧪"
   ${HCP_FLAG} \
   -s -o log_cli=true \
   ${DRY_RUN_FLAG} \
-  "${SKIP_ARGS[@]}" \
+  "${K_ARGS[@]}" \
   --data-collector \
   --data-collector-output-dir=${ARTIFACTS} \
   --pytest-log-file=${ARTIFACTS}/pytest-logs.txt \
@@ -198,12 +231,17 @@ wait ${TEST_PID} || true
 # Add manually deselected tests (via TEST_SKIPS) to the JUnit XML skipped count,
 # since pytest -k deselection omits them from the report entirely.
 # Only count entries that match real conformance test names.
+# Exclude any entries that also appear in TEST_FOCUS (those were not skipped).
 if [ -n "${TEST_SKIPS}" ]; then
   .venv/bin/python -c "
 import subprocess, sys, xml.etree.ElementTree as ET
 
 junit_path = sys.argv[1]
 skip_entries = sys.argv[2].split('|')
+focus_entries = sys.argv[3].split('|') if sys.argv[3] else []
+
+# Remove entries that are also in TEST_FOCUS (they were not skipped)
+skip_entries = [e for e in skip_entries if e not in focus_entries]
 
 # Collect all conformance test node IDs (without running them)
 result = subprocess.run(
@@ -224,5 +262,5 @@ if matched:
     for ts in tree.iter('testsuite'):
         ts.set('skipped', str(int(ts.get('skipped', '0')) + len(matched)))
     tree.write(junit_path, xml_declaration=True, encoding='unicode')
-" "${ARTIFACTS}/junit.results.xml" "${TEST_SKIPS}"
+" "${ARTIFACTS}/junit.results.xml" "${TEST_SKIPS}" "${TEST_FOCUS}"
 fi


### PR DESCRIPTION
Introduce a `TEST_FOCUS` environment variable that allows users to run only specific test cases matching the provided patterns, complementing the existing `TEST_SKIPS` parameter. The value is pipe-separated, same as `TEST_SKIPS`, and supports arbitrary test name patterns including spaces and special characters.

Implementation across all test suites:
- KubeVirt (compute/network/storage): translates to `--ginkgo.focus`
- SSP: translates to `--ginkgo.focus`
- Tier2: translates to `pytest -k` expression

When the same test appears in both `TEST_FOCUS` and `TEST_SKIPS`, a warning is printed and the test runs (`TEST_FOCUS` takes precedence). Overlapping entries are removed from the skip list before passing to the test runner.

Also relaxes the input validation regex for both `TEST_SKIPS` and `TEST_FOCUS` to accept any characters except the pipe delimiter, allowing test names with spaces, brackets, and other special characters.