### PR TITLE
feat: Add CI validation script for disconnected environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ test:
 .PHONY: ci-validate
 ci-validate:
 	@bash ci/run-ci-validation.sh
+
+.PHONY: ci-validate-disconnected
+ci-validate-disconnected:
+	@bash ci/run-ci-validation-disconnected.sh

--- a/ci/mirror-checkup-image-to-internal-registry.sh
+++ b/ci/mirror-checkup-image-to-internal-registry.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Mirror the validation checkup image to the OpenShift internal registry.
+#
+# The checkup image (OCP_VIRT_VALIDATION_IMAGE) is typically referenced by
+# digest from the CSV's relatedImages. Two problems prevent a straightforward
+# mirror to the internal registry:
+#
+# 1. The internal registry cannot serve multi-arch manifest lists. This script
+#    mirrors the image as single-arch (linux/amd64) so pods can pull it.
+#
+# 2. The workstation does not use the cluster's IDMS. For pre-GA images where
+#    the digest only exists in a mirror (e.g. Konflux builds), this script
+#    queries the cluster's ImageDigestMirrorSets and tries each mirror in order.
+#
+# Usage: mirror-checkup-image-to-internal-registry.sh <source-image> <internal-registry-route>
+# Output: prints the internal registry reference (by digest) to stdout
+
+set -euo pipefail
+
+SOURCE_IMAGE="$1"
+INTERNAL_REGISTRY="$2"
+
+IMAGE_BASE=$(echo "${SOURCE_IMAGE}" | sed 's|.*/||' | sed 's|[@:].*||')
+IMAGE_DIGEST=$(echo "${SOURCE_IMAGE}" | grep -o '@sha256:[a-f0-9]*' || true)
+IMAGE_SOURCE_REPO=$(echo "${SOURCE_IMAGE}" | sed 's|[@:].*||')
+MIRROR_TIMEOUT="${MIRROR_TIMEOUT:-300}"
+
+if [ -n "${IMAGE_DIGEST}" ]; then
+  INTERNAL_IMAGE="${INTERNAL_REGISTRY}/kubevirt-mirror/${IMAGE_BASE}:disconnected"
+else
+  IMAGE_TAG=$(echo "${SOURCE_IMAGE}" | sed 's|.*:||')
+  INTERNAL_IMAGE="${INTERNAL_REGISTRY}/kubevirt-mirror/${IMAGE_BASE}:${IMAGE_TAG}"
+fi
+
+MIRRORED=false
+if [ -n "${IMAGE_DIGEST}" ]; then
+  MIRROR_SOURCES=$(oc get imagedigestmirrorset -o json 2>/dev/null | \
+    jq -r --arg src "${IMAGE_SOURCE_REPO}" \
+    '.items[].spec.imageDigestMirrors[] | select(.source == $src) | .mirrors[]') || true
+
+  for mirror in ${MIRROR_SOURCES}; do
+    MIRROR_IMAGE="${mirror}${IMAGE_DIGEST}"
+    echo "> Trying mirror: ${MIRROR_IMAGE}" >&2
+    if timeout "${MIRROR_TIMEOUT}" oc image mirror --filter-by-os=linux/amd64 --insecure=true "${MIRROR_IMAGE}" "${INTERNAL_IMAGE}" >&2; then
+      echo "> Mirrored to: ${INTERNAL_IMAGE}" >&2
+      MIRRORED=true
+      break
+    fi
+  done
+fi
+
+if [ "${MIRRORED}" = false ]; then
+  echo "> No IDMS mirror worked, trying original source" >&2
+  timeout "${MIRROR_TIMEOUT}" oc image mirror --filter-by-os=linux/amd64 --insecure=true \
+    "${SOURCE_IMAGE}" "${INTERNAL_IMAGE}" >&2
+  echo "> Mirrored to: ${INTERNAL_IMAGE}" >&2
+fi
+
+IST_TAG="${IMAGE_BASE}:disconnected"
+if [ -z "${IMAGE_DIGEST}" ]; then
+  IST_TAG="${IMAGE_BASE}:${IMAGE_TAG}"
+fi
+
+INTERNAL_REF=$(oc get imagestreamtag "${IST_TAG}" -n kubevirt-mirror \
+  -o jsonpath='{.image.dockerImageReference}' 2>/dev/null) || true
+
+if [ -z "${INTERNAL_REF}" ]; then
+  echo "Error: Could not resolve image from internal registry (imagestreamtag ${IST_TAG} in kubevirt-mirror)" >&2
+  exit 1
+fi
+
+echo "${INTERNAL_REF}"

--- a/ci/run-ci-validation-disconnected.sh
+++ b/ci/run-ci-validation-disconnected.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SKIP_MIRROR_SETUP="${SKIP_MIRROR_SETUP:-false}"
+KUBEVIRT_RELEASE="${KUBEVIRT_RELEASE:-}"
+PULL_SECRET="${PULL_SECRET:-}"
+DRY_RUN="${DRY_RUN:-true}"
+OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT:-10m}"
+
+cleanup() {
+  rm -f "${CLUSTER_PULL_SECRET:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Pre-flight checks ==="
+for cmd in oc podman jq; do
+  if ! command -v "${cmd}" &>/dev/null; then
+    echo "Error: ${cmd} is required but not found in PATH"
+    exit 1
+  fi
+done
+
+if ! oc whoami &>/dev/null; then
+  echo "Error: not logged in to an OpenShift cluster (oc whoami failed)"
+  exit 1
+fi
+
+echo "> Pre-flight checks passed"
+
+echo "=== Cleaning up previous runs ==="
+oc delete imagetagmirrorset ocp-virt-validation-mirrors --ignore-not-found=true || true
+oc delete imagedigestmirrorset ocp-virt-validation-digest-mirrors --ignore-not-found=true || true
+oc delete namespace kubevirt-mirror --ignore-not-found=true --wait=true || true
+oc delete namespace ocp-virt-validation --ignore-not-found=true --wait=true || true
+echo "Waiting for MachineConfigPools to stabilize..."
+oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+echo "> Cleanup complete"
+
+echo "=== Authenticating to source registries ==="
+CLUSTER_PULL_SECRET=$(mktemp)
+oc get secret/pull-secret -n openshift-config \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > "${CLUSTER_PULL_SECRET}"
+
+for registry in registry.redhat.io quay.io/openshift-virtualization/konflux-builds; do
+  AUTH_B64=$(jq -r --arg r "${registry}" '.auths[$r].auth // empty' "${CLUSTER_PULL_SECRET}")
+  if [ -z "${AUTH_B64}" ]; then
+    echo "Warning: no credentials found for ${registry} in cluster pull secret, skipping" >&2
+    continue
+  fi
+  AUTH=$(echo "${AUTH_B64}" | base64 -d)
+  echo "${AUTH#*:}" | podman login -u "${AUTH%%:*}" --password-stdin "${registry}"
+done
+
+if [ "${SKIP_MIRROR_SETUP}" != "true" ]; then
+  echo "=== Mirroring images to internal registry and applying mirror sets ==="
+  MIRROR_ARGS=(--use-internal-registry --apply-mirror-set --never-contact-source)
+  [ -n "${KUBEVIRT_RELEASE}" ] && MIRROR_ARGS+=(--kubevirt-release "${KUBEVIRT_RELEASE}")
+  [ -n "${PULL_SECRET}" ] && MIRROR_ARGS+=(--pull-secret "${PULL_SECRET}")
+  "${REPO_ROOT}/disconnected/mirror-images.sh" "${MIRROR_ARGS[@]}"
+
+  echo "=== Waiting for all MachineConfigPool rollouts to complete ==="
+  oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+  sleep 30
+  oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
+  echo "> MachineConfigPools are stable"
+
+  echo "=== Re-mirroring images (registry pod may have restarted during MCP update) ==="
+  REMIRROR_ARGS=(--use-internal-registry)
+  [ -n "${KUBEVIRT_RELEASE}" ] && REMIRROR_ARGS+=(--kubevirt-release "${KUBEVIRT_RELEASE}")
+  [ -n "${PULL_SECRET}" ] && REMIRROR_ARGS+=(--pull-secret "${PULL_SECRET}")
+  "${REPO_ROOT}/disconnected/mirror-images.sh" "${REMIRROR_ARGS[@]}"
+else
+  echo "=== Skipping mirror setup (SKIP_MIRROR_SETUP=true) ==="
+fi
+
+echo "=== Authenticating to internal registry ==="
+INTERNAL_REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+LOGIN_TOKEN=$(oc create token registry-pusher -n kubevirt-mirror --duration=1h)
+echo "${LOGIN_TOKEN}" | podman login -u unused --password-stdin "${INTERNAL_REGISTRY}" --tls-verify=false
+
+if [ -n "${OCP_VIRT_VALIDATION_IMAGE:-}" ]; then
+  echo "=== Mirroring checkup image to internal registry ==="
+  echo "> Public image: ${OCP_VIRT_VALIDATION_IMAGE}"
+  OCP_VIRT_VALIDATION_IMAGE=$("${SCRIPT_DIR}/mirror-checkup-image-to-internal-registry.sh" \
+    "${OCP_VIRT_VALIDATION_IMAGE}" "${INTERNAL_REGISTRY}")
+  echo "> Using in-cluster image: ${OCP_VIRT_VALIDATION_IMAGE}"
+fi
+
+echo "=== Running disconnected validation checkup ==="
+OCP_VIRT_VALIDATION_IMAGE="${OCP_VIRT_VALIDATION_IMAGE:-}" \
+DRY_RUN="${DRY_RUN}" \
+OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT}" \
+  "${SCRIPT_DIR}/run-ci-validation.sh"
+
+echo "=== Disconnected validation checkup completed successfully ==="

--- a/disconnected/mirror-images.sh
+++ b/disconnected/mirror-images.sh
@@ -8,6 +8,7 @@ KUBEVIRT_RELEASE=""
 MIRROR_REGISTRY=""
 USE_INTERNAL_REGISTRY=false
 APPLY_MIRROR_SET=false
+NEVER_CONTACT_SOURCE=false
 PULL_SECRET="${PULL_SECRET:-}"
 TLS_VERIFY=true
 
@@ -47,6 +48,7 @@ Options:
   --pull-secret FILE           Path to pull secret for registry authentication
   --insecure                   Skip TLS verification for the mirror registry
   --apply-mirror-set           Generate and apply ITMS + IDMS after mirroring
+  --never-contact-source       Set mirrorSourcePolicy to NeverContactSource in mirror sets
   -h, --help                   Show this help message
 
 Examples:
@@ -70,6 +72,7 @@ while [[ $# -gt 0 ]]; do
     --pull-secret)    PULL_SECRET="$2"; shift 2 ;;
     --insecure)       TLS_VERIFY=false; shift ;;
     --apply-mirror-set)      APPLY_MIRROR_SET=true; shift ;;
+    --never-contact-source)  NEVER_CONTACT_SOURCE=true; shift ;;
     -h|--help)        usage ;;
     *)                echo "Unknown option: $1"; usage ;;
   esac
@@ -338,6 +341,11 @@ generate_mirror_set() {
     other_prefix="${MIRROR_REGISTRY}"
   fi
 
+  local source_policy=""
+  if [ "${NEVER_CONTACT_SOURCE}" = true ]; then
+    source_policy=$'\n      mirrorSourcePolicy: NeverContactSource'
+  fi
+
   cat > "${mirror_set_file}" <<EOF
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet
@@ -347,13 +355,13 @@ spec:
   imageTagMirrors:
     - source: quay.io/kubevirt
       mirrors:
-        - ${target_prefix}
+        - ${target_prefix}${source_policy}
     - source: quay.io/openshift-cnv
       mirrors:
-        - ${tier2_prefix}
+        - ${tier2_prefix}${source_policy}
     - source: registry.redhat.io/rhel9
       mirrors:
-        - ${other_prefix}
+        - ${other_prefix}${source_policy}
 ---
 apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
@@ -363,13 +371,13 @@ spec:
   imageDigestMirrors:
     - source: quay.io/kubevirt
       mirrors:
-        - ${target_prefix}
+        - ${target_prefix}${source_policy}
     - source: quay.io/openshift-cnv
       mirrors:
-        - ${tier2_prefix}
+        - ${tier2_prefix}${source_policy}
     - source: registry.redhat.io/rhel9
       mirrors:
-        - ${other_prefix}
+        - ${other_prefix}${source_policy}
 EOF
 
   echo ""


### PR DESCRIPTION
## Summary

- Add `ci/run-ci-validation-disconnected.sh` and `make ci-validate-disconnected` target to run the validation checkup simulating a disconnected (air-gapped) environment
- Add `ci/mirror-checkup-image-to-internal-registry.sh` helper to mirror the checkup image to the internal registry
- Add `--never-contact-source` flag to `disconnected/mirror-images.sh` to set `mirrorSourcePolicy: NeverContactSource` in the generated ITMS/IDMS mirror sets

## What this PR does / why we need it

The disconnected CI script orchestrates a full disconnected validation run on a connected cluster:

1. Authenticates to source registries (`registry.redhat.io` and Konflux) using the cluster pull secret
2. Calls `mirror-images.sh` with `--never-contact-source` to mirror KubeVirt images and apply ITMS/IDMS with `NeverContactSource` policy, ensuring nodes never pull from the original source
4. Mirrors the checkup image to the internal registry
5. Runs the validation checkup as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)