### PR TITLE
CNV-71660: Fix incorrect "Tests Run" count for pytest-based suites

### DIFF
--- a/ci/Dockerfile.ci
+++ b/ci/Dockerfile.ci
@@ -25,25 +25,38 @@ RUN GOOS=linux CGO_ENABLED=1 go test -c -o bin/ssp.test ./tests
 
 
 ################################################################################
-# Build Stage 3: Utilities and Tier2 Tests
+# Build Stage 3: Utilities
 ################################################################################
 FROM docker.io/library/golang:1.23 AS utilities-builder
 
-# Build arguments for user permissions
-ARG USER_UID=1001
-
-# Build junit_parser and progress_watcher utilities
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-# Clone openshift-virtualization-tests repository for tier2 tests
+
+################################################################################
+# Build Stage 4: Tier2 Tests (Python venv)
+################################################################################
+FROM registry.access.redhat.com/ubi9/ubi:9.6 AS cnv-tests-builder
+
+ARG USER_UID=1001
 ARG OPENSHIFT_VIRT_TESTS_REPO=https://github.com/RedHatQE/openshift-virtualization-tests.git
 ARG OPENSHIFT_VIRT_TESTS_BRANCH=main
 ARG TEST_DIR=/openshift-virtualization-tests
 
-RUN git clone --depth 1 --branch ${OPENSHIFT_VIRT_TESTS_BRANCH} ${OPENSHIFT_VIRT_TESTS_REPO} ${TEST_DIR} && \
-    chown -R ${USER_UID}:0 ${TEST_DIR} && \
+RUN dnf -y install python3-devel gcc cargo openssl-devel sshpass \
+        libcurl-devel libxslt-devel libxml2-devel git which && \
+    dnf clean all
+
+RUN pip3 install uv
+
+RUN git clone --depth 1 --branch ${OPENSHIFT_VIRT_TESTS_BRANCH} ${OPENSHIFT_VIRT_TESTS_REPO} ${TEST_DIR}
+
+WORKDIR ${TEST_DIR}
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+RUN uv sync --locked
+
+RUN chown -R ${USER_UID}:0 ${TEST_DIR} && \
     chmod -R ug+rwx ${TEST_DIR}
 
 
@@ -62,7 +75,8 @@ ENV USER_UID=${USER_UID} \
     HOME=${HOME}
 
 # Install system dependencies and OpenShift CLI tools
-RUN microdnf install -y jq make tar gzip python3 git which sshpass findutils grep sed && \
+RUN microdnf install -y jq make tar gzip python3 git which sshpass findutils grep sed \
+        libxslt libxml2 libatomic && \
     microdnf clean all && \
     curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar xzf - -C /usr/local/bin oc kubectl && \
     mkdir -p ${HOME} && \
@@ -81,8 +95,9 @@ COPY --from=ssp-builder --chown=${USER_UID}:0 --chmod=775 /workspace/bin/ssp.tes
 COPY --from=utilities-builder --chown=${USER_UID}:0 --chmod=775 /workspace/bin/junit_parser /usr/local/bin/junit_parser
 COPY --from=utilities-builder --chown=${USER_UID}:0 --chmod=775 /workspace/bin/progress_watcher /usr/local/bin/progress_watcher
 
-# Copy openshift-virtualization-tests for tier2 test suite
-COPY --from=utilities-builder --chown=${USER_UID}:0 --chmod=775 /openshift-virtualization-tests /openshift-virtualization-tests
+# Copy uv-managed Python and openshift-virtualization-tests (with .venv) for tier2
+COPY --from=cnv-tests-builder --chown=${USER_UID}:0 --chmod=775 /opt/python/ /opt/python/
+COPY --from=cnv-tests-builder --chown=${USER_UID}:0 --chmod=775 /openshift-virtualization-tests /openshift-virtualization-tests
 
 # Create convenience symlinks for common commands
 RUN ln -s ${HOME}/manifests/run/generate.sh /usr/local/bin/generate && \

--- a/result/result.go
+++ b/result/result.go
@@ -32,28 +32,27 @@ func New(junitResults map[string]junit.TestSuite) Result {
 			continue
 		}
 
-		// Count skipped tests from testsuite header OR individual test cases
-		skipped := testSuite.Skipped + testSuite.Disabled
+		// headerSkipped is the count from the testsuite XML attributes.
+		// Only this value should be used to adjust testsRun, because the
+		// header "tests" attribute includes skipped tests in pytest/SSP
+		// but excludes them in Ginkgo.
+		headerSkipped := testSuite.Skipped + testSuite.Disabled
 
-		// If testsuite header doesn't have skipped count, count individual skipped test cases
-		if skipped == 0 {
+		// displaySkipped is what we show in the summary. When the header
+		// doesn't report skipped counts (Ginkgo), fall back to counting
+		// individual testcase elements so the report still shows the total.
+		displaySkipped := headerSkipped
+		if displaySkipped == 0 {
 			for _, testCase := range testSuite.TestCases {
 				if testCase.Skipped {
-					skipped++
+					displaySkipped++
 				}
 			}
 		}
 
-		// Count both failures and errors as failures
 		totalFailures := testSuite.Failures + testSuite.Errors
-		passed := testSuite.Tests - totalFailures
-
-		// For SSP, exclude skipped tests from both run count and passed count
-		testsRun := testSuite.Tests
-		if sig == "ssp" {
-			testsRun = testSuite.Tests - skipped
-			passed = testsRun - totalFailures
-		}
+		testsRun := max(testSuite.Tests-headerSkipped, 0)
+		passed := max(testsRun-totalFailures, 0)
 
 		// Convert time from seconds to duration string format (rounded to whole seconds)
 		var durationStr string
@@ -68,7 +67,7 @@ func New(junitResults map[string]junit.TestSuite) Result {
 			Run:      testsRun,
 			Passed:   passed,
 			Failures: totalFailures,
-			Skipped:  skipped,
+			Skipped:  displaySkipped,
 			Duration: durationStr,
 		}
 
@@ -87,7 +86,7 @@ func New(junitResults map[string]junit.TestSuite) Result {
 		res.Summary.Run += testsRun
 		res.Summary.Passed += passed
 		res.Summary.Failed += totalFailures
-		res.Summary.Skipped += skipped
+		res.Summary.Skipped += displaySkipped
 	}
 
 	return res

--- a/result/results_test.go
+++ b/result/results_test.go
@@ -34,11 +34,11 @@ func TestCreatesResultWithValidJUnitResults(t *testing.T) {
 	}
 
 	sig1 := res.SigMap["sig1"]
-	if sig1.Run != 5 {
-		t.Errorf("expected 5 tests run for sig1, got %d", sig1.Run)
+	if sig1.Run != 4 {
+		t.Errorf("expected 4 tests run for sig1 (5 total - 1 skipped), got %d", sig1.Run)
 	}
-	if sig1.Passed != 4 {
-		t.Errorf("expected 4 tests passed for sig1, got %d", sig1.Passed)
+	if sig1.Passed != 3 {
+		t.Errorf("expected 3 tests passed for sig1 (4 run - 1 failed), got %d", sig1.Passed)
 	}
 	if sig1.Failures != 1 {
 		t.Errorf("expected 1 failure for sig1, got %d", sig1.Failures)
@@ -81,11 +81,35 @@ func TestHandlesEmptyJUnitResults(t *testing.T) {
 	}
 }
 
-func TestHandlesSpecialSigLogicForSSP(t *testing.T) {
+func TestExcludesSkippedFromRunCountForAnySuite(t *testing.T) {
 	junitResults := map[string]junit.TestSuite{
-		"ssp": {
-			Tests:    4,
+		"tier2": {
+			Tests:    10,
 			Failures: 1,
+			Skipped:  3,
+			Disabled: 0,
+		},
+	}
+
+	res := result.New(junitResults)
+
+	sig := res.SigMap["tier2"]
+	if sig.Run != 7 {
+		t.Errorf("expected 7 tests run (10 total - 3 skipped), got %d", sig.Run)
+	}
+	if sig.Passed != 6 {
+		t.Errorf("expected 6 tests passed (7 run - 1 failed), got %d", sig.Passed)
+	}
+	if sig.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", sig.Failures)
+	}
+}
+
+func TestAllTestsSkippedDoesNotProduceNegativeCounts(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"tier2": {
+			Tests:    0,
+			Failures: 0,
 			Skipped:  2,
 			Disabled: 0,
 		},
@@ -93,15 +117,46 @@ func TestHandlesSpecialSigLogicForSSP(t *testing.T) {
 
 	res := result.New(junitResults)
 
-	sig := res.SigMap["ssp"]
-	if sig.Run != 2 {
-		t.Errorf("expected 2 tests run for ssp (4 total - 2 skipped), got %d", sig.Run)
+	sig := res.SigMap["tier2"]
+	if sig.Run != 0 {
+		t.Errorf("expected 0 tests run (all skipped), got %d", sig.Run)
 	}
-	if sig.Passed != 1 {
-		t.Errorf("expected 1 test passed for ssp (2 run - 1 failed), got %d", sig.Passed)
+	if sig.Passed != 0 {
+		t.Errorf("expected 0 tests passed, got %d", sig.Passed)
 	}
-	if sig.Failures != 1 {
-		t.Errorf("expected 1 failure for ssp, got %d", sig.Failures)
+	if sig.Skipped != 2 {
+		t.Errorf("expected 2 skipped, got %d", sig.Skipped)
+	}
+}
+
+func TestGinkgoSkippedOnlyInTestcasesDoesNotAffectRunCount(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"network": {
+			Tests:    18,
+			Failures: 1,
+			Skipped:  0,
+			Disabled: 0,
+			TestCases: []junit.TestCase{
+				{Name: "test1", Failure: true},
+				{Name: "test2"},
+				{Name: "skipped1", Skipped: true},
+				{Name: "skipped2", Skipped: true},
+				{Name: "skipped3", Skipped: true},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+
+	sig := res.SigMap["network"]
+	if sig.Run != 18 {
+		t.Errorf("expected 18 tests run (header skipped=0, testcase skips should not reduce run count), got %d", sig.Run)
+	}
+	if sig.Passed != 17 {
+		t.Errorf("expected 17 tests passed (18 run - 1 failed), got %d", sig.Passed)
+	}
+	if sig.Skipped != 3 {
+		t.Errorf("expected 3 skipped for display (from testcase elements), got %d", sig.Skipped)
 	}
 }
 

--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -144,12 +144,7 @@ else
   STORAGE_CLASS_CONFIG=""
 fi
 
-if [ "${DRY_RUN}" == "true" ]
-then
-  DRY_RUN_FLAG="--collect-only"
-else
-  DRY_RUN_FLAG=""
-fi
+DRY_RUN_FLAG=""
 
 # Check if cluster is running on hosted control plane
 CONTROL_PLANE_TOPOLOGY=$(oc get infrastructure cluster -o jsonpath='{.status.controlPlaneTopology}' 2>/dev/null || echo "")
@@ -204,36 +199,112 @@ fi
 
 echo "Starting tier2 tests 🧪"
 
-(set +e; .venv/bin/pytest \
-  -m "conformance" \
-  -W "ignore::pytest.PytestRemovedIn9Warning" \
-  --skip-artifactory-check \
-  --latest-rhel \
-  --tc=hco_subscription:${SUBSCRIPTION_NAME} \
-  --conformance-storage-class=${STORAGE_CLASS} \
-  ${STORAGE_CLASS_CONFIG} \
-  ${HCP_FLAG} \
-  -s -o log_cli=true \
-  ${DRY_RUN_FLAG} \
-  "${K_ARGS[@]}" \
-  --data-collector \
-  --data-collector-output-dir=${ARTIFACTS} \
-  --pytest-log-file=${ARTIFACTS}/pytest-logs.txt \
-  --junitxml="${ARTIFACTS}/junit.results.xml"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/tier2-log.txt &
+if [ "${DRY_RUN}" == "true" ]; then
+  # In dry-run mode, collect tests and generate a proper JUnit XML with all
+  # testcase elements -- aligned with how Ginkgo's --ginkgo.dry-run works.
+  (set +e; .venv/bin/pytest \
+    -m "conformance" \
+    -W "ignore::pytest.PytestRemovedIn9Warning" \
+    --skip-artifactory-check \
+    --latest-rhel \
+    --tc=hco_subscription:${SUBSCRIPTION_NAME} \
+    --conformance-storage-class=${STORAGE_CLASS} \
+    ${STORAGE_CLASS_CONFIG} \
+    ${HCP_FLAG} \
+    --collect-only -q \
+    "${K_ARGS[@]}" \
+    2>&1; echo $? > "${ARTIFACTS}/.exit_code") | tee ${ARTIFACTS}/tier2-log.txt &
 
-# Store the PID for cleanup
-TEST_PID=$!
-echo "Tier2 test process started with PID: ${TEST_PID}"
+  TEST_PID=$!
+  echo "Tier2 test process started with PID: ${TEST_PID}"
+  wait ${TEST_PID} || true
 
-# Wait for the test to complete
-wait ${TEST_PID} || true
-
-# Add manually deselected tests (via TEST_SKIPS) to the JUnit XML skipped count,
-# since pytest -k deselection omits them from the report entirely.
-# Only count entries that match real conformance test names.
-# Exclude any entries that also appear in TEST_FOCUS (those were not skipped).
-if [ -n "${TEST_SKIPS}" ]; then
+  # Generate JUnit XML from collected test IDs, accounting for TEST_SKIPS
   .venv/bin/python -c "
+import subprocess, sys, socket
+from xml.etree.ElementTree import Element, SubElement, ElementTree
+from datetime import datetime, timezone
+
+log_path = sys.argv[1]
+junit_path = sys.argv[2]
+skip_entries = sys.argv[3].split('|') if sys.argv[3] else []
+focus_entries = sys.argv[4].split('|') if sys.argv[4] else []
+
+# Remove entries that are also in TEST_FOCUS (they were not skipped)
+skip_entries = [e for e in skip_entries if e not in focus_entries]
+
+with open(log_path) as f:
+    lines = f.readlines()
+
+test_ids = [l.strip() for l in lines if '::' in l and not l.startswith(('=', '-', ' '))]
+
+# Count TEST_SKIPS entries that match real conformance tests (these were
+# deselected by -k and don't appear in the collected list above).
+skipped_count = 0
+if skip_entries:
+    result = subprocess.run(
+        ['.venv/bin/pytest', '--collect-only', '-q', '-m', 'conformance'],
+        capture_output=True, text=True
+    )
+    all_collected = result.stdout
+    matched = [e for e in skip_entries if e in all_collected]
+    skipped_count = len(matched)
+    if matched:
+        print(f'TEST_SKIPS: {skipped_count} test(s) would be skipped: {matched}')
+
+total_tests = len(test_ids) + skipped_count
+
+testsuites = Element('testsuites', name='pytest tests')
+ts = SubElement(testsuites, 'testsuite',
+    name='pytest',
+    errors='0',
+    failures='0',
+    skipped=str(skipped_count),
+    tests=str(total_tests),
+    time='0.000',
+    timestamp=datetime.now(timezone.utc).isoformat(),
+    hostname=socket.gethostname(),
+)
+
+for tid in test_ids:
+    parts = tid.split('::')
+    module = parts[0].replace('/', '.').removesuffix('.py') if parts else ''
+    name = parts[-1] if parts else tid
+    classname = '.'.join(parts[:-1]).replace('/', '.').removesuffix('.py') if len(parts) > 1 else module
+    SubElement(ts, 'testcase', classname=classname, name=name, time='0.000')
+
+tree = ElementTree(testsuites)
+tree.write(junit_path, xml_declaration=True, encoding='unicode')
+print(f'Generated JUnit XML with {total_tests} test(s) ({len(test_ids)} collected, {skipped_count} skipped via TEST_SKIPS)')
+" "${ARTIFACTS}/tier2-log.txt" "${ARTIFACTS}/junit.results.xml" "${TEST_SKIPS:-}" "${TEST_FOCUS:-}"
+
+else
+  (set +e; .venv/bin/pytest \
+    -m "conformance" \
+    -W "ignore::pytest.PytestRemovedIn9Warning" \
+    --skip-artifactory-check \
+    --latest-rhel \
+    --tc=hco_subscription:${SUBSCRIPTION_NAME} \
+    --conformance-storage-class=${STORAGE_CLASS} \
+    ${STORAGE_CLASS_CONFIG} \
+    ${HCP_FLAG} \
+    -s -o log_cli=true \
+    "${K_ARGS[@]}" \
+    --data-collector \
+    --data-collector-output-dir=${ARTIFACTS} \
+    --pytest-log-file=${ARTIFACTS}/pytest-logs.txt \
+    --junitxml="${ARTIFACTS}/junit.results.xml"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/tier2-log.txt &
+
+  TEST_PID=$!
+  echo "Tier2 test process started with PID: ${TEST_PID}"
+  wait ${TEST_PID} || true
+
+  # Add manually deselected tests (via TEST_SKIPS) to the JUnit XML skipped count,
+  # since pytest -k deselection omits them from the report entirely.
+  # Only count entries that match real conformance test names.
+  # Exclude any entries that also appear in TEST_FOCUS (those were not skipped).
+  if [ -n "${TEST_SKIPS}" ]; then
+    .venv/bin/python -c "
 import subprocess, sys, xml.etree.ElementTree as ET
 
 junit_path = sys.argv[1]
@@ -260,7 +331,9 @@ print(f'Matched {len(matched)} real test(s) to mark as skipped: {skipped_names}'
 if matched:
     tree = ET.parse(junit_path)
     for ts in tree.iter('testsuite'):
+        ts.set('tests', str(int(ts.get('tests', '0')) + len(matched)))
         ts.set('skipped', str(int(ts.get('skipped', '0')) + len(matched)))
     tree.write(junit_path, xml_declaration=True, encoding='unicode')
 " "${ARTIFACTS}/junit.results.xml" "${TEST_SKIPS}" "${TEST_FOCUS}"
+  fi
 fi


### PR DESCRIPTION
The summary report incorrectly included skipped tests in the "Tests Run" count for pytest-based suites (tier2). This happened because only the "ssp" suite had a special case to subtract skipped tests from the total, while the same logic applies to any suite whose JUnit XML includes skipped tests in the "tests" attribute (as pytest does).

Replace the SSP-specific branch with a universal calculation that uses the header-level skipped count to adjust testsRun:
  testsRun = tests - headerSkipped

Separately, the display skipped count falls back to counting individual testcase elements when the header reports zero (as Ginkgo does). This distinction is critical: Ginkgo's "tests" attribute already excludes skipped tests, so only header-reported skips should affect the run count.

Guard against negative values when all tests are skipped (e.g. pytest reports tests=0, skipped=2 when every test is filtered out).

Fix tier2 dry-run to generate a proper JUnit XML with all collected testcase elements, aligned with Ginkgo's --ginkgo.dry-run behavior. Previously, pytest --collect-only produced tests=0 in JUnit, making the dry-run summary meaningless. The TEST_SKIPS post-processing is now scoped to non-dry-run execution only.