### PR TITLE
Flatten multi-arch images when mirroring to internal registry

### DIFF
--- a/disconnected/mirror-images.sh
+++ b/disconnected/mirror-images.sh
@@ -191,6 +191,11 @@ setup_internal_registry() {
 
 get_mirror_flags() {
   local flags=""
+  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
+    flags+="--filter-by-os=linux/amd64 "
+  else
+    flags+="--keep-manifest-list=true "
+  fi
   if [ "${TLS_VERIFY}" = false ]; then
     flags+="--insecure=true "
   fi
@@ -222,7 +227,7 @@ mirror_kubevirt_images() {
     echo "  ${source}"
     echo "  -> ${target}"
 
-    if oc image mirror --keep-manifest-list=true ${flags} \
+    if oc image mirror ${flags} \
       "${source}" "${target}" 2>&1; then
       echo "  OK"
     else
@@ -261,7 +266,7 @@ mirror_tier2_images() {
     echo "  ${full_image}"
     echo "  -> ${target}"
 
-    if oc image mirror --keep-manifest-list=true ${flags} \
+    if oc image mirror ${flags} \
       "${full_image}" "${target}" 2>&1; then
       echo "  OK"
     else
@@ -299,7 +304,7 @@ mirror_other_images() {
     echo "  ${full_image}"
     echo "  -> ${target}"
 
-    if oc image mirror --keep-manifest-list=true ${flags} \
+    if oc image mirror ${flags} \
       "${full_image}" "${target}" 2>&1; then
       echo "  OK"
     else


### PR DESCRIPTION
The OpenShift internal image registry does not support manifest lists (multi-arch images). When images like disk-images-provider are pushed as manifest lists, node pulls fail because the registry cannot resolve the list to a platform-specific image.

Centralize the manifest-list handling in get_mirror_flags() so that:
- Internal registry: uses --filter-by-os=linux/amd64 to flatten to a single-arch image the registry can serve.
- External registry: preserves --keep-manifest-list=true to retain full multi-arch support.