### PR TITLE
Replace podman login with oc registry login in disconnected scripts

### DIFF
--- a/ci/run-ci-validation-disconnected.sh
+++ b/ci/run-ci-validation-disconnected.sh
@@ -17,7 +17,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "=== Pre-flight checks ==="
-for cmd in oc podman jq; do
+for cmd in oc jq; do
   if ! command -v "${cmd}" &>/dev/null; then
     echo "Error: ${cmd} is required but not found in PATH"
     exit 1
@@ -52,7 +52,7 @@ for registry in registry.redhat.io quay.io/openshift-virtualization/konflux-buil
     continue
   fi
   AUTH=$(echo "${AUTH_B64}" | base64 -d)
-  echo "${AUTH#*:}" | podman login -u "${AUTH%%:*}" --password-stdin "${registry}"
+  oc registry login --registry="${registry}" --auth-basic="${AUTH%%:*}:${AUTH#*:}"
 done
 
 if [ "${SKIP_MIRROR_SETUP}" != "true" ]; then
@@ -80,7 +80,7 @@ fi
 echo "=== Authenticating to internal registry ==="
 INTERNAL_REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
 LOGIN_TOKEN=$(oc create token registry-pusher -n kubevirt-mirror --duration=1h)
-echo "${LOGIN_TOKEN}" | podman login -u unused --password-stdin "${INTERNAL_REGISTRY}" --tls-verify=false
+oc registry login --registry="${INTERNAL_REGISTRY}" --auth-basic="unused:${LOGIN_TOKEN}" --insecure=true
 
 if [ -n "${OCP_VIRT_VALIDATION_IMAGE:-}" ]; then
   echo "=== Mirroring checkup image to internal registry ==="

--- a/disconnected/mirror-images.sh
+++ b/disconnected/mirror-images.sh
@@ -186,8 +186,7 @@ setup_internal_registry() {
     login_token=$(oc whoami -t)
   fi
 
-  echo "${login_token}" | podman login -u "${login_user}" --password-stdin "${MIRROR_REGISTRY}" \
-    --tls-verify=false
+  oc registry login --registry="${MIRROR_REGISTRY}" --auth-basic="${login_user}:${login_token}" --insecure=true
 
   TLS_VERIFY=false
 }


### PR DESCRIPTION
## Summary

- Replace all `podman login` calls with `oc registry login --auth-basic` in disconnected CI scripts
- Remove `podman` from the pre-flight check in `run-ci-validation-disconnected.sh`
- `oc registry login` writes the same credentials to `auth.json` that `podman login` does, so `oc image mirror` works unchanged

## More details

The CI build root image (`rhel-9-release-golang-1.24-openshift-4.22`) does not have `podman` installed. Since `oc` is already available and `oc registry login --registry=REGISTRY --auth-basic=USER:PASS` writes credentials to the same `auth.json` file, we can eliminate the `podman` dependency entirely.

## What this PR does / why we need it

Removes 3 `podman login` calls across 2 scripts:
- `ci/run-ci-validation-disconnected.sh`: 2 calls (source registries + internal registry)
- `disconnected/mirror-images.sh`: 1 call (internal registry in `setup_internal_registry()`)

## Test plan

- [x] `DRY_RUN=true` — completed successfully
- [x] `DRY_RUN=false TEST_SUITES=storage` — **70 tests passed, 0 failed** (84 min, disconnected environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)