### PR TITLE
CNV-75328: Group tier2 failed tests by SIG category in summary

### DIFF
--- a/result/result.go
+++ b/result/result.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,10 +73,11 @@ func New(junitResults map[string]junit.TestSuite) Result {
 		}
 
 		if totalFailures > 0 {
-			var failedTests []string
+			failedTests := make(map[string][]string)
 			for _, testCase := range testSuite.TestCases {
 				if testCase.Failure || testCase.Error {
-					failedTests = append(failedTests, testCase.Name)
+					category := extractCategory(testCase.Classname)
+					failedTests[category] = append(failedTests[category], testCase.Name)
 				}
 			}
 
@@ -97,12 +99,49 @@ type SigMap map[string]Sig
 
 // Sig represents the result of a test suite, including the number of tests run, passed, failed, and skipped.
 type Sig struct {
-	Run         int      `json:"tests_run"`
-	Passed      int      `json:"tests_passed"`
-	Failures    int      `json:"tests_failures"`
-	Skipped     int      `json:"tests_skipped"`
-	Duration    string   `json:"tests_duration,omitempty"`
-	FailedTests []string `json:"failed_tests,omitempty"`
+	Run         int            `json:"tests_run"`
+	Passed      int            `json:"tests_passed"`
+	Failures    int            `json:"tests_failures"`
+	Skipped     int            `json:"tests_skipped"`
+	Duration    string         `json:"tests_duration,omitempty"`
+	FailedTests FailedTestsMap `json:"failed_tests,omitempty"`
+}
+
+// FailedTestsMap holds failed test names grouped by category.
+// An empty-string key means the test has no category (e.g. Ginkgo suites).
+// JSON/YAML: serialises as a flat []string when there is only the
+// uncategorised bucket, and as map[string][]string otherwise, so that
+// existing consumers of the ConfigMap are not broken by this change.
+type FailedTestsMap map[string][]string
+
+func (f FailedTestsMap) MarshalJSON() ([]byte, error) {
+	if f.isFlat() {
+		return json.Marshal(f[""])
+	}
+	return json.Marshal(map[string][]string(f))
+}
+
+func (f *FailedTestsMap) UnmarshalJSON(data []byte) error {
+	var flat []string
+	if err := json.Unmarshal(data, &flat); err == nil {
+		*f = FailedTestsMap{"": flat}
+		return nil
+	}
+
+	var m map[string][]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	*f = FailedTestsMap(m)
+	return nil
+}
+
+func (f FailedTestsMap) isFlat() bool {
+	if len(f) != 1 {
+		return false
+	}
+	_, ok := f[""]
+	return ok
 }
 
 type Summary struct {
@@ -172,9 +211,7 @@ func (r Result) String() string {
 
 		if len(sigRes.FailedTests) > 0 {
 			sb.WriteString("Failed Tests:\n")
-			for _, testName := range sigRes.FailedTests {
-				sb.WriteString(fmt.Sprintf("  - %s\n", testName))
-			}
+			writeFailedTests(&sb, sigRes.FailedTests)
 		}
 	}
 
@@ -193,6 +230,65 @@ func (r Result) String() string {
 	sb.WriteString(fmt.Sprintf("Total Tests Skipped: %d\n", r.Summary.Skipped))
 
 	return sb.String()
+}
+
+// writeFailedTests writes the failed tests map to the string builder.
+// When all tests share a single uncategorized bucket (empty key), a flat list is produced.
+// Otherwise, tests are grouped under sorted category headings.
+func writeFailedTests(sb *strings.Builder, failedTests map[string][]string) {
+	_, hasUncategorized := failedTests[""]
+	if len(failedTests) == 1 && hasUncategorized {
+		for _, testName := range failedTests[""] {
+			sb.WriteString(fmt.Sprintf("  - %s\n", testName))
+		}
+		return
+	}
+
+	categories := make([]string, 0, len(failedTests))
+	for cat := range failedTests {
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+
+	for _, cat := range categories {
+		label := cat
+		if label == "" {
+			label = "uncategorized"
+		}
+		sb.WriteString(fmt.Sprintf("  %s:\n", label))
+		for _, testName := range failedTests[cat] {
+			sb.WriteString(fmt.Sprintf("    - %s\n", testName))
+		}
+	}
+}
+
+// extractCategory derives a SIG category from a pytest classname.
+// Pytest classnames follow the pattern "tests.<category>.<subpath>...",
+// e.g. "tests.storage.test_hotplug.TestHotPlugWithPersist" → "storage".
+// For "virt", the second level is included to distinguish sub-areas,
+// e.g. "tests.virt.cluster.general.test_smbios" → "virt/cluster",
+//
+//	"tests.virt.node.cpu_sockets_threads.test_cpu" → "virt/node".
+//
+// Returns an empty string for non-pytest classnames (e.g. Ginkgo's "Tests Suite").
+func extractCategory(classname string) string {
+	const prefix = "tests."
+	if !strings.HasPrefix(classname, prefix) {
+		return ""
+	}
+
+	rest := classname[len(prefix):]
+	parts := strings.SplitN(rest, ".", 3)
+	if len(parts) == 0 {
+		return ""
+	}
+
+	category := parts[0]
+	if category == "virt" && len(parts) >= 2 {
+		return category + "/" + parts[1]
+	}
+
+	return category
 }
 
 // GetYaml converts the Result struct to YAML format.

--- a/result/results_test.go
+++ b/result/results_test.go
@@ -2,9 +2,11 @@ package result_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"junitparser/junit_parser/junit"
 	"junitparser/result"
-	"testing"
 )
 
 func TestCreatesResultWithValidJUnitResults(t *testing.T) {
@@ -15,8 +17,8 @@ func TestCreatesResultWithValidJUnitResults(t *testing.T) {
 			Skipped:  1,
 			Disabled: 0,
 			TestCases: []junit.TestCase{
-				{Name: "test1", Failure: true},
-				{Name: "test2"},
+				{Name: "test1", Classname: "Tests Suite", Failure: true},
+				{Name: "test2", Classname: "Tests Suite"},
 			},
 		},
 		"sig2": {
@@ -43,8 +45,9 @@ func TestCreatesResultWithValidJUnitResults(t *testing.T) {
 	if sig1.Failures != 1 {
 		t.Errorf("expected 1 failure for sig1, got %d", sig1.Failures)
 	}
-	if len(sig1.FailedTests) != 1 || sig1.FailedTests[0] != "test1" {
-		t.Errorf("expected failed test 'test1' for sig1, got %v", sig1.FailedTests)
+	uncategorized := sig1.FailedTests[""]
+	if len(uncategorized) != 1 || uncategorized[0] != "test1" {
+		t.Errorf("expected failed test 'test1' under empty category for sig1, got %v", sig1.FailedTests)
 	}
 
 	sig2 := res.SigMap["sig2"]
@@ -168,7 +171,7 @@ func TestMarshalsResultToJSONCorrectly(t *testing.T) {
 			Skipped:  0,
 			Disabled: 0,
 			TestCases: []junit.TestCase{
-				{Name: "test1", Failure: true},
+				{Name: "test1", Classname: "Tests Suite", Failure: true},
 			},
 		},
 	}
@@ -240,6 +243,144 @@ func TestSetupFailureWithOtherValidSuites(t *testing.T) {
 	}
 }
 
+func TestCategorizesFailedTestsByClassname(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"tier2": {
+			Tests:    5,
+			Failures: 3,
+			Skipped:  0,
+			Disabled: 0,
+			TestCases: []junit.TestCase{
+				{Name: "test_hotplug_volume", Classname: "tests.storage.test_hotplug.TestHotPlug", Failure: true},
+				{Name: "test_smbios_default", Classname: "tests.virt.cluster.general.test_smbios", Failure: true},
+				{Name: "test_namespace_health", Classname: "tests.after_cluster_deploy_sanity.test_sanity", Failure: true},
+				{Name: "test_passing", Classname: "tests.virt.node.test_node"},
+				{Name: "test_also_passing", Classname: "tests.storage.test_resize"},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+
+	sig := res.SigMap["tier2"]
+	if sig.Failures != 3 {
+		t.Errorf("expected 3 failures, got %d", sig.Failures)
+	}
+
+	if len(sig.FailedTests) != 3 {
+		t.Errorf("expected 3 categories, got %d: %v", len(sig.FailedTests), sig.FailedTests)
+	}
+
+	storageTests := sig.FailedTests["storage"]
+	if len(storageTests) != 1 || storageTests[0] != "test_hotplug_volume" {
+		t.Errorf("expected storage category with 'test_hotplug_volume', got %v", storageTests)
+	}
+
+	virtTests := sig.FailedTests["virt/cluster"]
+	if len(virtTests) != 1 || virtTests[0] != "test_smbios_default" {
+		t.Errorf("expected virt/cluster category with 'test_smbios_default', got %v", virtTests)
+	}
+
+	sanityTests := sig.FailedTests["after_cluster_deploy_sanity"]
+	if len(sanityTests) != 1 || sanityTests[0] != "test_namespace_health" {
+		t.Errorf("expected after_cluster_deploy_sanity category with 'test_namespace_health', got %v", sanityTests)
+	}
+}
+
+func TestCategorizedStringOutputIsHierarchical(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"tier2": {
+			Tests:    4,
+			Failures: 3,
+			Skipped:  0,
+			Disabled: 0,
+			TestCases: []junit.TestCase{
+				{Name: "test_hotplug", Classname: "tests.storage.test_hotplug.TestHotPlug", Failure: true},
+				{Name: "test_smbios", Classname: "tests.virt.cluster.general.test_smbios", Failure: true},
+				{Name: "test_cpu", Classname: "tests.virt.node.cpu_sockets_threads.test_cpu", Failure: true},
+				{Name: "test_passing", Classname: "tests.virt.node.test_node"},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+	output := res.String()
+
+	if !strings.Contains(output, "  storage:\n") {
+		t.Errorf("expected output to contain 'storage:' category header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "  virt/cluster:\n") {
+		t.Errorf("expected output to contain 'virt/cluster:' category header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "  virt/node:\n") {
+		t.Errorf("expected output to contain 'virt/node:' category header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "    - test_hotplug") {
+		t.Errorf("expected output to contain indented test_hotplug, got:\n%s", output)
+	}
+	if !strings.Contains(output, "    - test_smbios") {
+		t.Errorf("expected output to contain indented test_smbios, got:\n%s", output)
+	}
+	if !strings.Contains(output, "    - test_cpu") {
+		t.Errorf("expected output to contain indented test_cpu, got:\n%s", output)
+	}
+}
+
+func TestUncategorizedStringOutputIsFlat(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"compute": {
+			Tests:    2,
+			Failures: 1,
+			Skipped:  0,
+			Disabled: 0,
+			TestCases: []junit.TestCase{
+				{Name: "test_migration", Classname: "Tests Suite", Failure: true},
+				{Name: "test_passing", Classname: "Tests Suite"},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+	output := res.String()
+
+	if !strings.Contains(output, "  - test_migration") {
+		t.Errorf("expected output to contain flat '  - test_migration', got:\n%s", output)
+	}
+	if strings.Contains(output, ":\n    -") {
+		t.Errorf("expected no category headers in uncategorized output, got:\n%s", output)
+	}
+}
+
+func TestCategorizedJSONOutputUsesMap(t *testing.T) {
+	junitResults := map[string]junit.TestSuite{
+		"tier2": {
+			Tests:    3,
+			Failures: 2,
+			Skipped:  0,
+			Disabled: 0,
+			TestCases: []junit.TestCase{
+				{Name: "test_hotplug", Classname: "tests.storage.test_hotplug.TestHotPlug", Failure: true},
+				{Name: "test_smbios", Classname: "tests.virt.cluster.general.test_smbios", Failure: true},
+				{Name: "test_passing", Classname: "tests.virt.node.test_node"},
+			},
+		},
+	}
+
+	res := result.New(junitResults)
+	jsonData, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling result to JSON: %v", err)
+	}
+
+	jsonStr := string(jsonData)
+	if !strings.Contains(jsonStr, `"storage":["test_hotplug"]`) {
+		t.Errorf("expected JSON to contain categorized storage tests, got %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"virt/cluster":["test_smbios"]`) {
+		t.Errorf("expected JSON to contain categorized virt/cluster tests, got %s", jsonStr)
+	}
+}
+
 func TestConvertsResultToYAMLCorrectly(t *testing.T) {
 	junitResults := map[string]junit.TestSuite{
 		"sig1": {
@@ -248,7 +389,7 @@ func TestConvertsResultToYAMLCorrectly(t *testing.T) {
 			Skipped:  0,
 			Disabled: 0,
 			TestCases: []junit.TestCase{
-				{Name: "test1", Failure: true},
+				{Name: "test1", Classname: "Tests Suite", Failure: true},
 			},
 		},
 	}


### PR DESCRIPTION
Extract the test category from the pytest JUnit classname field (e.g. `tests.storage.test_hotplug.TestHotPlug` → `storage`) and group failed tests under their category in the summary output.

For `virt` tests, the second path level is included to distinguish sub-areas (`virt/cluster` vs `virt/node`).

Ginkgo-based suites (compute, network, storage) are unaffected — their classname is "Tests Suite" which produces no category, so the flat list format and ConfigMap YAML structure are preserved via a custom `FailedTestsMap` JSON marshaler.

Before:
```
  Failed Tests:
    - test_hotplug_volume_with_bus_and_persist[...]
    - test_vm_smbios_default_values
    - test_migration_policy_successfully_applied[by_namespace_label_selector]
    - test_vm_with_cpu_support[case1: 2 cores, 2 threads, 2 sockets]
```
After:
```
Failed Tests:
    storage:
      - test_hotplug_volume_with_bus_and_persist[...]
    virt/cluster:
      - test_vm_smbios_default_values
      - test_migration_policy_successfully_applied[by_namespace_label_selector]
    virt/node:
      - test_vm_with_cpu_support[case1: 2 cores, 2 threads, 2 sockets]
```