### PR TITLE
CNV-88743: fix: redirect TEST_FOCUS/TEST_SKIPS overlap warning to stderr

### DIFF
--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -65,7 +65,7 @@ if [[ -n "${TEST_FOCUS}" && -n "${TEST_SKIPS}" ]]; then
   for f in "${focus_entries[@]}"; do
     for s in "${skip_entries[@]}"; do
       if [[ "${f}" == "${s}" ]]; then
-        echo "WARNING: '${f}' appears in both TEST_FOCUS and TEST_SKIPS. TEST_FOCUS takes precedence; test will run."
+        echo "WARNING: '${f}' appears in both TEST_FOCUS and TEST_SKIPS. TEST_FOCUS takes precedence; test will run." >&2
       fi
     done
   done


### PR DESCRIPTION
When a test appears in both `TEST_FOCUS` and `TEST_SKIPS`, `generate.sh` emits a warning to stdout. Since users pipe the output directly to `oc apply -f -`, this produces malformed YAML and breaks the apply. Redirect the warning to stderr so the YAML stream stays clean.