### PR TITLE
fix: label namespace with privileged PSA for OCP 5.0 compatibility

### DIFF
--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -462,6 +462,8 @@ if ! oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
   oc create namespace "${GOLDEN_IMAGE_NAMESPACE}"
 fi
 
+oc label namespace "${GOLDEN_IMAGE_NAMESPACE}" pod-security.kubernetes.io/enforce=privileged --overwrite
+
 # Step 4: Check if golden image DataSource already exists
 echo "Checking if Windows golden image already exists..."
 if oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then


### PR DESCRIPTION
following https://github.com/openshift-cnv/ocp-virt-validation-checkup/pull/67, OCP 5.0, Pod Security Admission rejects Tekton task pods in namespaces with the default restricted policy. The SCC grant alone is no longer sufficient.

This adds `pod-security.kubernetes.io/enforce=privileged` label to the golden image namespace before creating the PipelineRun. No harm on OCP 4.x.

Found during end-to-end testing on OCP 5.0 cluster.


