### PR TITLE
Revert image flattening and clean node images before disconnected tests

### DIFF
--- a/ci/run-ci-validation-disconnected.sh
+++ b/ci/run-ci-validation-disconnected.sh
@@ -32,6 +32,7 @@ fi
 echo "> Pre-flight checks passed"
 
 echo "=== Cleaning up previous runs ==="
+for node in $(oc get node -o NAME); do oc debug -n default "${node}" -- chroot /host crictl rmi --prune; done || true
 oc delete imagetagmirrorset ocp-virt-validation-mirrors --ignore-not-found=true || true
 oc delete imagedigestmirrorset ocp-virt-validation-digest-mirrors --ignore-not-found=true || true
 oc delete namespace kubevirt-mirror --ignore-not-found=true --wait=true || true

--- a/disconnected/mirror-images.sh
+++ b/disconnected/mirror-images.sh
@@ -193,11 +193,6 @@ setup_internal_registry() {
 
 get_mirror_flags() {
   local flags=""
-  if [ "${USE_INTERNAL_REGISTRY}" = true ]; then
-    flags+="--filter-by-os=linux/amd64 "
-  else
-    flags+="--keep-manifest-list=true "
-  fi
   if [ "${TLS_VERIFY}" = false ]; then
     flags+="--insecure=true "
   fi
@@ -229,7 +224,7 @@ mirror_kubevirt_images() {
     echo "  ${source}"
     echo "  -> ${target}"
 
-    if oc image mirror ${flags} \
+    if oc image mirror --keep-manifest-list=true ${flags} \
       "${source}" "${target}" 2>&1; then
       echo "  OK"
     else
@@ -268,7 +263,7 @@ mirror_tier2_images() {
     echo "  ${full_image}"
     echo "  -> ${target}"
 
-    if oc image mirror ${flags} \
+    if oc image mirror --keep-manifest-list=true ${flags} \
       "${full_image}" "${target}" 2>&1; then
       echo "  OK"
     else
@@ -306,7 +301,7 @@ mirror_other_images() {
     echo "  ${full_image}"
     echo "  -> ${target}"
 
-    if oc image mirror ${flags} \
+    if oc image mirror --keep-manifest-list=true ${flags} \
       "${full_image}" "${target}" 2>&1; then
       echo "  OK"
     else


### PR DESCRIPTION
## Summary
- Revert the multi-arch image flattening when mirroring to the internal registry: always use `--keep-manifest-list=true` instead of `--filter-by-os=linux/amd64` for internal registry mirrors.
- Clean images stored in nodes (`crictl rmi --prune`) before running disconnected tests to avoid stale cached images from previous runs.

## More details

The `--filter-by-os` flag (when using internal registry) was flattening multi-arch manifests into single-arch images when mirroring to the internal registry. This caused issues because the manifest list are needed for running tier2 testsuite. Reverting to `--keep-manifest-list=true` preserves the original manifest structure for all mirror targets.

Additionally, a cleanup step is added at the beginning of the disconnected CI script to prune container images cached on each node, preventing leftover images from prior runs from interfering with the test.

## What this PR does / why we need it

1. **Reverts commit a43f8b2**: removes the conditional `--filter-by-os=linux/amd64` flag for internal registry mirrors and restores `--keep-manifest-list=true` for all mirror operations.
2. **Adds node image cleanup**: runs `crictl rmi --prune` on all nodes before mirroring, ensuring a clean state for disconnected validation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)