### PR TITLE
Switch Windows golden image from Win11 to Server 2022

### DIFF
--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -202,9 +202,13 @@ fi
 # When Windows tests are added with this marker, they will be automatically included
 # when ACCEPT_WINDOWS_EULA=true
 MARKERS="conformance"
+WIN_IMAGE_FLAG=""
 if [ "${ACCEPT_WINDOWS_EULA}" == "true" ]; then
   echo "Windows EULA accepted - Windows tests will be included when available"
   MARKERS="${MARKERS} or windows"
+  # WIN_USERNAME/WIN_PASSWORD: defaults match setup-golden-image.sh output (Administrator/Heslo123),
+  # but can be overridden for custom golden images with different credentials
+  WIN_IMAGE_FLAG="--tc=win_golden_image_name:${WIN_IMAGE_NAME:-windows2022-golden-image} --tc=os_login_param.win.username:${WIN_USERNAME:-Administrator} --tc=os_login_param.win.password:${WIN_PASSWORD:-Heslo123} --tc=storage_class_a:${STORAGE_CLASS} --tc=storage_class_b:${STORAGE_CLASS}"
 fi
 
 echo "Starting tier2 tests 🧪"
@@ -222,6 +226,7 @@ if [ "${DRY_RUN}" == "true" ]; then
     --conformance-storage-class=${STORAGE_CLASS} \
     ${STORAGE_CLASS_CONFIG} \
     ${HCP_FLAG} \
+    ${WIN_IMAGE_FLAG} \
     --collect-only -q \
     "${K_ARGS[@]}" \
     2>&1; echo $? > "${ARTIFACTS}/.exit_code") | tee ${ARTIFACTS}/tier2-log.txt &
@@ -299,6 +304,7 @@ else
     --conformance-storage-class=${STORAGE_CLASS} \
     ${STORAGE_CLASS_CONFIG} \
     ${HCP_FLAG} \
+    ${WIN_IMAGE_FLAG} \
     -s -o log_cli=true \
     "${K_ARGS[@]}" \
     --data-collector \

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 #
-# Setup Windows 11 Golden Image for Self-Validation
+# Setup Windows Server 2022 Golden Image for Self-Validation
 #
-# This script creates a Windows 11 golden image using the windows-efi-installer
-# Tekton pipeline, then boots the sysprepped image with an unattend.xml to
-# complete OOBE automatically. The final DataSource produces VMs that boot
-# directly to the desktop with no manual setup.
+# Creates a ready-to-use Windows Server 2022 golden image using the
+# windows-efi-installer Tekton pipeline with a custom autounattend.
+# The resulting DataSource produces VMs that boot directly to the desktop
+# with OpenSSH enabled and firewall disabled — no manual setup needed.
 #
 # Flow:
-#   1. Pipeline installs Windows + sysprep (creates sysprepped disk)
-#   2. Create a temporary DataSource from the sysprepped disk
-#   3. Boot from that DataSource with unattend.xml on SATA CD-ROM (skips OOBE)
-#   4. Wait for guest agent + stabilization time
-#   5. Snapshot the running VM at desktop state
-#   6. Create final DataSource from snapshot (this is the golden image)
+#   1. Pipeline downloads the ISO and injects our custom autounattend.xml
+#   2. VM boots and installs Windows Server 2022 (Desktop Experience)
+#   3. FirstLogonCommands run post-update.ps1 (guest agent, OpenSSH, firewall, cleanup)
+#   4. VM shuts down automatically after configuration
+#   5. Snapshot the disk and create a DataSource (this is the golden image)
 #
 # Prerequisites:
 # - OpenShift Pipelines operator installed
@@ -30,24 +29,19 @@ set -e
 
 GOLDEN_IMAGE_NAMESPACE="openshift-virtualization-os-images"
 
-DEFAULT_WIN_GOLDEN_IMAGE_NAME="windows11-golden-image"
+DEFAULT_WIN_GOLDEN_IMAGE_NAME="windows2022-golden-image"
 GOLDEN_IMAGE_NAME="${WIN_IMAGE_NAME:-${DEFAULT_WIN_GOLDEN_IMAGE_NAME}}"
 
-DEFAULT_WIN_IMAGE_URL="https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENT_CONSUMER_x64FRE_en-us.iso"
+DEFAULT_WIN_IMAGE_URL="https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
 WIN_IMAGE_URL="${WIN_IMAGE_DOWNLOAD_URL:-${DEFAULT_WIN_IMAGE_URL}}"
 
 PIPELINE_VERSION="${TEKTON_PIPELINE_VERSION:->=v4.21.0}"
 
-# u1.large provides enough vCPUs for Windows 11 (4 vCPUs, 8Gi RAM)
 DEFAULT_INSTANCE_TYPE="u1.large"
 INSTANCE_TYPE="${WIN_INSTANCE_TYPE:-${DEFAULT_INSTANCE_TYPE}}"
 
-# Derived names for intermediate resources
-# WIN_SYSPREP_PVC allows pointing to an existing sysprepped PVC (skips pipeline)
-SYSPREP_DV_NAME="${WIN_SYSPREP_PVC:-${GOLDEN_IMAGE_NAME}-sysprep}"
-SYSPREP_DS_NAME="${GOLDEN_IMAGE_NAME}-sysprep-ds"
-OOBE_VM_NAME="${GOLDEN_IMAGE_NAME}-oobe-setup"
-OOBE_CONFIGMAP_NAME="${GOLDEN_IMAGE_NAME}-unattend"
+AUTOUNATTEND_CM_NAME="${GOLDEN_IMAGE_NAME}-autounattend"
+SYSPREP_DV_NAME="${WIN_SYSPREP_PVC:-${GOLDEN_IMAGE_NAME}}"
 SNAPSHOT_NAME="${GOLDEN_IMAGE_NAME}-snap"
 
 VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS:-}"
@@ -81,13 +75,6 @@ sys.exit(1)
   echo "Auto-detected VolumeSnapshotClass: ${VOLUME_SNAPSHOT_CLASS} (provisioner: ${sc_provisioner})"
 }
 
-cleanup_oobe_resources() {
-  echo "Cleaning up temporary OOBE resources..."
-  oc delete vm "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" --wait=false 2>/dev/null || true
-  oc delete configmap "${OOBE_CONFIGMAP_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-  oc delete datasource "${SYSPREP_DS_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-}
-
 cleanup_pipeline_sa() {
   if [ "${CREATED_PIPELINE_SA}" == "true" ]; then
     echo "Cleaning up pipeline service account permissions..."
@@ -97,31 +84,98 @@ cleanup_pipeline_sa() {
   fi
 }
 
-create_unattend_configmap() {
-  echo "Creating unattend.xml ConfigMap for OOBE automation..."
-  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<UNATTENDEOF
+cleanup_autounattend_cm() {
+  oc delete configmap "${AUTOUNATTEND_CM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+}
+
+create_autounattend_configmap() {
+  echo "Creating custom autounattend ConfigMap for Windows Server 2022..."
+  oc delete configmap "${AUTOUNATTEND_CM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ${OOBE_CONFIGMAP_NAME}
+  name: ${AUTOUNATTEND_CM_NAME}
   labels:
     app: ocp-virt-validation
 data:
-  unattend.xml: |
+  autounattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>
     <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
-      <settings pass="specialize">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-          <ComputerName>WinVM</ComputerName>
-          <TimeZone>UTC</TimeZone>
+      <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <SetupUILanguage>
+            <UILanguage>en-US</UILanguage>
+          </SetupUILanguage>
+          <InputLocale>0409:00000409</InputLocale>
+          <SystemLocale>en-US</SystemLocale>
+          <UILanguage>en-US</UILanguage>
+          <UserLocale>en-US</UserLocale>
         </component>
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-          <RunSynchronous>
-            <RunSynchronousCommand wcm:action="add">
-              <Order>1</Order>
-              <Path>reg add "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
-            </RunSynchronousCommand>
-          </RunSynchronous>
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <DriverPaths>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+              <Path>E:\\</Path>
+            </PathAndCredentials>
+          </DriverPaths>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <DiskConfiguration>
+            <WillShowUI>Never</WillShowUI>
+            <Disk wcm:action="add">
+              <CreatePartitions>
+                  <CreatePartition wcm:action="add">
+                      <Order>1</Order>
+                      <Type>EFI</Type>
+                      <Size>100</Size>
+                  </CreatePartition>
+                  <CreatePartition wcm:action="add">
+                      <Order>2</Order>
+                      <Type>MSR</Type>
+                      <Size>16</Size>
+                  </CreatePartition>
+                  <CreatePartition wcm:action="add">
+                      <Order>3</Order>
+                      <Type>Primary</Type>
+                      <Extend>true</Extend>
+                  </CreatePartition>
+              </CreatePartitions>
+              <ModifyPartitions>
+                <ModifyPartition wcm:action="add">
+                    <Order>1</Order>
+                    <PartitionID>1</PartitionID>
+                    <Label>EFI</Label>
+                    <Format>FAT32</Format>
+                </ModifyPartition>
+                <ModifyPartition wcm:action="add">
+                    <Order>2</Order>
+                    <PartitionID>3</PartitionID>
+                    <Label>Windows</Label>
+                    <Letter>C</Letter>
+                    <Format>NTFS</Format>
+                </ModifyPartition>
+              </ModifyPartitions>
+              <DiskID>0</DiskID>
+              <WillWipeDisk>true</WillWipeDisk>
+            </Disk>
+          </DiskConfiguration>
+          <ImageInstall>
+            <OSImage>
+              <InstallFrom>
+                <MetaData wcm:action="add">
+                  <Key>/Image/Index</Key>
+                  <Value>2</Value>
+                </MetaData>
+              </InstallFrom>
+              <InstallTo>
+                <DiskID>0</DiskID>
+                <PartitionID>3</PartitionID>
+              </InstallTo>
+            </OSImage>
+          </ImageInstall>
+          <UserData>
+            <AcceptEula>true</AcceptEula>
+          </UserData>
         </component>
       </settings>
       <settings pass="oobeSystem">
@@ -129,291 +183,95 @@ data:
           <InputLocale>0409:00000409</InputLocale>
           <SystemLocale>en-US</SystemLocale>
           <UILanguage>en-US</UILanguage>
+          <UILanguageFallback>en-US</UILanguageFallback>
           <UserLocale>en-US</UserLocale>
         </component>
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <UserAccounts>
+            <AdministratorPassword>
+              <Value>Heslo123</Value>
+              <PlainText>true</PlainText>
+            </AdministratorPassword>
+          </UserAccounts>
+          <AutoLogon>
+            <Enabled>true</Enabled>
+            <Password>
+              <Value>Heslo123</Value>
+              <PlainText>true</PlainText>
+            </Password>
+            <Username>Administrator</Username>
+          </AutoLogon>
+          <TimeZone>UTC</TimeZone>
           <OOBE>
             <HideEULAPage>true</HideEULAPage>
             <HideLocalAccountScreen>true</HideLocalAccountScreen>
             <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
             <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
             <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-            <NetworkLocation>Home</NetworkLocation>
+            <NetworkLocation>Work</NetworkLocation>
             <ProtectYourPC>3</ProtectYourPC>
-            <SkipMachineOOBE>true</SkipMachineOOBE>
-            <SkipUserOOBE>true</SkipUserOOBE>
           </OOBE>
-          <UserAccounts>
-            <LocalAccounts>
-              <LocalAccount wcm:action="add">
-                <Password>
-                  <Value>Admin123!</Value>
-                  <PlainText>true</PlainText>
-                </Password>
-                <DisplayName>Admin</DisplayName>
-                <Group>Administrators</Group>
-                <Name>Admin</Name>
-              </LocalAccount>
-            </LocalAccounts>
-          </UserAccounts>
-          <AutoLogon>
-            <Password>
-              <Value>Admin123!</Value>
-              <PlainText>true</PlainText>
-            </Password>
-            <Enabled>true</Enabled>
-            <Username>Admin</Username>
-          </AutoLogon>
+          <FirstLogonCommands>
+            <SynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile F:\\post-update.ps1</CommandLine>
+              <Description>Install SSH and configure system</Description>
+            </SynchronousCommand>
+          </FirstLogonCommands>
         </component>
       </settings>
     </unattend>
-UNATTENDEOF
-  echo "ConfigMap '${OOBE_CONFIGMAP_NAME}' created"
-}
+  post-update.ps1: |
+    # Critical section - abort on any failure
+    \$ErrorActionPreference = 'Stop'
 
-create_sysprep_datasource() {
-  echo "Creating temporary DataSource from sysprepped PVC..."
-  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataSource
-metadata:
-  name: ${SYSPREP_DS_NAME}
-  labels:
-    app: ocp-virt-validation
-spec:
-  source:
-    pvc:
-      name: ${SYSPREP_DV_NAME}
-      namespace: ${GOLDEN_IMAGE_NAMESPACE}
+    # Install QEMU guest agent
+    Start-Process msiexec -Wait -ArgumentList "/i E:\\guest-agent\\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+    # Install and start OpenSSH server
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    Set-Service -Name sshd -StartupType Automatic
+    Start-Service sshd
+
+    # Disable Windows Firewall entirely
+    Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+    # Non-critical cleanup - continue on error
+    \$ErrorActionPreference = 'Continue'
+
+    # Suppress network location wizard and set profile
+    New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
+    Set-NetConnectionProfile -InterfaceAlias "Ethernet" -NetworkCategory Private -ErrorAction SilentlyContinue
+
+    # Disable Server Manager auto-launch
+    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Value 1
+
+    # Cleanup for smaller image
+    \$PageFile = Get-CimInstance -ClassName Win32_PageFileSetting -Filter "Name like '%pagefile.sys'"
+    if (\$PageFile) {
+      \$PageFile | Remove-CimInstance
+      \$PageFile = New-CimInstance -ClassName Win32_PageFileSetting -Property @{ Name= "C:\\pagefile.sys" }
+      \$PageFile | Set-CimInstance -Property @{ InitialSize = 0; MaximumSize = 0 }
+    }
+    Vssadmin delete shadows /all /quiet
+    Remove-Item -Path \$env:Temp -Recurse -Force -ErrorAction SilentlyContinue
+    dism.exe /online /Cleanup-Image /StartComponentCleanup
+    powercfg -h off
+
+    # Rename cached unattend.xml to prevent sysprep issues
+    if (Test-Path "C:\\Windows\\Panther\\unattend.xml") {
+      mv C:\\Windows\\Panther\\unattend.xml C:\\Windows\\Panther\\unattend.install.xml
+    }
+
+    # Eject CD and shut down
+    (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
+    Stop-Computer -Force
 EOF
-  echo "DataSource '${SYSPREP_DS_NAME}' created"
-}
-
-create_oobe_vm() {
-  echo "Creating temporary VM to complete OOBE automatically..."
-  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
-apiVersion: kubevirt.io/v1
-kind: VirtualMachine
-metadata:
-  name: ${OOBE_VM_NAME}
-  labels:
-    app: ocp-virt-validation
-spec:
-  runStrategy: Always
-  instancetype:
-    kind: VirtualMachineClusterInstancetype
-    name: ${INSTANCE_TYPE}
-  preference:
-    kind: VirtualMachineClusterPreference
-    name: windows.11.virtio
-  dataVolumeTemplates:
-    - metadata:
-        name: ${OOBE_VM_NAME}-disk
-      spec:
-        storage:
-          resources:
-            requests:
-              storage: 20Gi
-          storageClassName: ${STORAGE_CLASS}
-        sourceRef:
-          kind: DataSource
-          name: ${SYSPREP_DS_NAME}
-          namespace: ${GOLDEN_IMAGE_NAMESPACE}
-  template:
-    spec:
-      domain:
-        devices:
-          disks:
-            - name: rootdisk
-              disk:
-                bus: virtio
-            - name: sysprep
-              cdrom:
-                bus: sata
-          interfaces:
-            - name: default
-              masquerade: {}
-      networks:
-        - name: default
-          pod: {}
-      volumes:
-        - name: rootdisk
-          dataVolume:
-            name: ${OOBE_VM_NAME}-disk
-        - name: sysprep
-          sysprep:
-            configMap:
-              name: ${OOBE_CONFIGMAP_NAME}
-EOF
-  echo "VM '${OOBE_VM_NAME}' created"
-}
-
-wait_for_dv_ready() {
-  local dv_name="${OOBE_VM_NAME}-disk"
-  echo "Waiting for DataVolume '${dv_name}' clone to complete..."
-  local timeout=1200
-  local interval=15
-  local elapsed=0
-
-  while [ ${elapsed} -lt ${timeout} ]; do
-    local dv_phase dv_progress
-    dv_phase=$(oc get dv "${dv_name}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-      -o jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
-    dv_progress=$(oc get dv "${dv_name}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-      -o jsonpath='{.status.progress}' 2>/dev/null || echo "N/A")
-
-    case "${dv_phase}" in
-      "Succeeded")
-        echo "DataVolume clone complete (${dv_progress})"
-        return 0
-        ;;
-      "Failed")
-        echo "ERROR: DataVolume clone failed"
-        oc get dv "${dv_name}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o yaml | tail -20
-        return 1
-        ;;
-      *)
-        echo "[${elapsed}s] DV phase: ${dv_phase}, progress: ${dv_progress}"
-        ;;
-    esac
-
-    sleep ${interval}
-    elapsed=$((elapsed + interval))
-  done
-
-  echo "ERROR: Timeout waiting for DataVolume clone (${timeout}s)"
-  return 1
-}
-
-wait_for_vm_running() {
-  echo "Waiting for VM to reach Running phase..."
-  local timeout=300
-  local interval=10
-  local elapsed=0
-
-  while [ ${elapsed} -lt ${timeout} ]; do
-    local phase
-    phase=$(oc get vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-      -o jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
-
-    if [ "${phase}" == "Running" ]; then
-      echo "VM is Running"
-      return 0
-    fi
-
-    echo "[${elapsed}s] VM phase: ${phase}"
-    sleep ${interval}
-    elapsed=$((elapsed + interval))
-  done
-
-  echo "ERROR: Timeout waiting for VM to start (${timeout}s)"
-  oc describe vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null | tail -30
-  return 1
-}
-
-wait_for_desktop() {
-  echo "Waiting for guest agent to report Windows OS..."
-  local timeout=600
-  local interval=15
-  local elapsed=0
-
-  while [ ${elapsed} -lt ${timeout} ]; do
-    local guest_os
-    guest_os=$(oc get vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-      -o jsonpath='{.status.guestOSInfo.name}' 2>/dev/null || echo "")
-
-    if echo "${guest_os}" | grep -qi "windows"; then
-      echo "Guest agent reports: ${guest_os}"
-      echo "Polling for guest agent IP (indicates OOBE complete and desktop reached)..."
-      local ip_timeout=600
-      local ip_elapsed=0
-      while [ ${ip_elapsed} -lt ${ip_timeout} ]; do
-        local guest_ip
-        guest_ip=$(oc get vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-          -o jsonpath='{.status.interfaces[0].ipAddress}' 2>/dev/null || echo "")
-        if [ -n "${guest_ip}" ]; then
-          echo "Guest agent reports IP: ${guest_ip} - Windows OOBE completed"
-          return 0
-        fi
-        echo "[${ip_elapsed}s] Waiting for guest agent IP..."
-        sleep 15
-        ip_elapsed=$((ip_elapsed + 15))
-      done
-      echo "ERROR: Timeout waiting for guest agent IP after OOBE"
-      return 1
-    fi
-
-    echo "[${elapsed}s] Guest OS: ${guest_os:-not detected yet}"
-
-    sleep ${interval}
-    elapsed=$((elapsed + interval))
-  done
-
-  echo "ERROR: Timeout waiting for Windows guest agent (${timeout}s)"
-  return 1
-}
-
-create_snapshot() {
-  echo "Creating VolumeSnapshot of desktop-ready VM disk..."
-  oc delete volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: ${SNAPSHOT_NAME}
-  labels:
-    app: ocp-virt-validation
-spec:
-  volumeSnapshotClassName: ${VOLUME_SNAPSHOT_CLASS}
-  source:
-    persistentVolumeClaimName: ${OOBE_VM_NAME}-disk
-EOF
-
-  echo "Waiting for snapshot to be ready..."
-  local timeout=120
-  local interval=5
-  local elapsed=0
-
-  while [ ${elapsed} -lt ${timeout} ]; do
-    local ready
-    ready=$(oc get volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-      -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
-
-    if [ "${ready}" == "true" ]; then
-      echo "VolumeSnapshot '${SNAPSHOT_NAME}' is ready"
-      return 0
-    fi
-
-    sleep ${interval}
-    elapsed=$((elapsed + interval))
-  done
-
-  echo "ERROR: Timeout waiting for snapshot to become ready"
-  return 1
-}
-
-create_datasource() {
-  echo "Creating DataSource '${GOLDEN_IMAGE_NAME}' from snapshot..."
-  oc delete datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-  oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataSource
-metadata:
-  name: ${GOLDEN_IMAGE_NAME}
-  labels:
-    app: ocp-virt-validation
-spec:
-  source:
-    snapshot:
-      name: ${SNAPSHOT_NAME}
-      namespace: ${GOLDEN_IMAGE_NAMESPACE}
-EOF
-  echo "DataSource '${GOLDEN_IMAGE_NAME}' created"
 }
 
 # --- Main Script ---
 
-echo "=== Windows Golden Image Setup ==="
+echo "=== Windows Server 2022 Golden Image Setup ==="
 
 # Step 1: Check if EULA is accepted
 if [ "${ACCEPT_WINDOWS_EULA}" != "true" ]; then
@@ -435,21 +293,6 @@ if ! oc get crd pipelines.tekton.dev &>/dev/null; then
   echo "  1. Go to OperatorHub in the OpenShift Console"
   echo "  2. Search for 'Red Hat OpenShift Pipelines'"
   echo "  3. Install the operator"
-  echo ""
-  echo "Or install via CLI:"
-  echo "  oc apply -f - <<INSTALLEOF"
-  echo "apiVersion: operators.coreos.com/v1alpha1"
-  echo "kind: Subscription"
-  echo "metadata:"
-  echo "  name: openshift-pipelines-operator-rh"
-  echo "  namespace: openshift-operators"
-  echo "spec:"
-  echo "  channel: stable"
-  echo "  installPlanApproval: Automatic"
-  echo "  name: openshift-pipelines-operator-rh"
-  echo "  source: redhat-operators"
-  echo "  sourceNamespace: openshift-marketplace"
-  echo "INSTALLEOF"
   exit 1
 fi
 
@@ -481,8 +324,9 @@ if ! oc get sa pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
   oc adm policy add-scc-to-user privileged -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
   oc adm policy add-role-to-user edit -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
   CREATED_PIPELINE_SA=true
-  trap cleanup_pipeline_sa EXIT
 fi
+
+trap 'cleanup_pipeline_sa; cleanup_autounattend_cm' EXIT
 
 # Step 6: Verify storage class and detect snapshot class
 if [ -z "${STORAGE_CLASS}" ]; then
@@ -496,19 +340,21 @@ echo "Using snapshot class: ${VOLUME_SNAPSHOT_CLASS}"
 echo "Using Windows ISO URL: ${WIN_IMAGE_URL}"
 echo "Using instance type: ${INSTANCE_TYPE}"
 
-# Step 7: Check if sysprepped PVC already exists (skip pipeline if so)
+# Step 7: Create custom autounattend ConfigMap
+create_autounattend_configmap
+
+# Step 8: Check if PVC already exists (skip pipeline if so)
 if oc get pvc "${SYSPREP_DV_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
-  echo "Sysprepped PVC '${SYSPREP_DV_NAME}' already exists - skipping pipeline"
+  echo "PVC '${SYSPREP_DV_NAME}' already exists - skipping pipeline"
 else
   echo ""
-  echo "=== Phase 1: Creating sysprepped Windows disk via pipeline ==="
-  echo "Using hub resolver to fetch pipeline from artifacthub (version: ${PIPELINE_VERSION})"
+  echo "=== Running Windows Server 2022 Installation Pipeline ==="
 
 PIPELINE_RUN_NAME=$(oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF | grep -oP 'pipelinerun.tekton.dev/\K[^ ]+'
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  generateName: windows11-golden-
+  generateName: win2022-golden-
   labels:
     app: ocp-virt-validation
 spec:
@@ -541,9 +387,11 @@ spec:
     - name: instanceTypeKind
       value: "VirtualMachineClusterInstancetype"
     - name: preferenceName
-      value: "windows.11.virtio"
+      value: "windows.2k22"
     - name: preferenceKind
       value: "VirtualMachineClusterPreference"
+    - name: autounattendConfigMapName
+      value: "${AUTOUNATTEND_CM_NAME}"
   taskRunSpecs:
     - pipelineTaskName: modify-windows-iso-file
       podTemplate:
@@ -560,9 +408,8 @@ fi
 
 echo "Created PipelineRun: ${PIPELINE_RUN_NAME}"
 
-# Step 8: Wait for pipeline to complete
-echo "Waiting for Windows installation to complete..."
-echo "This may take up to 3 hours for first-time setup"
+# Step 9: Wait for pipeline to complete
+echo "Waiting for Windows installation to complete (this may take up to 3 hours)..."
 
 TIMEOUT_SECONDS=10800
 POLL_INTERVAL=60
@@ -575,17 +422,12 @@ while [ ${ELAPSED} -lt ${TIMEOUT_SECONDS} ]; do
   case "${STATUS}" in
     "Succeeded")
       echo "Pipeline completed successfully!"
-      echo "Sysprepped disk '${SYSPREP_DV_NAME}' is ready"
       break
       ;;
     "Failed"|"PipelineRunTimeout"|"TaskRunCancelled"|"CouldntGetPipeline")
       echo "ERROR: Pipeline failed with status: ${STATUS}"
-      echo ""
       if [ "${STATUS}" == "CouldntGetPipeline" ]; then
-        echo "Failed to fetch pipeline from artifacthub. This could mean:"
-        echo "  1. No internet access (hub resolver requires network)"
-        echo "  2. The pipeline version ${PIPELINE_VERSION} doesn't exist"
-        echo ""
+        echo "Failed to fetch pipeline from artifacthub."
         echo "For disconnected environments, manually install the pipeline first:"
         echo "  https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer"
       fi
@@ -610,84 +452,69 @@ fi
 
 fi  # end of pipeline skip check
 
-# Step 9: Complete OOBE automatically
+# Step 10: Create snapshot from the ready PVC
 echo ""
-echo "=== Phase 2: Completing OOBE automatically ==="
-echo "Booting sysprepped image with unattend.xml to skip OOBE..."
+echo "=== Creating Golden Image Snapshot ==="
 
-trap cleanup_oobe_resources EXIT
+oc delete volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${SNAPSHOT_NAME}
+  labels:
+    app: ocp-virt-validation
+spec:
+  volumeSnapshotClassName: ${VOLUME_SNAPSHOT_CLASS}
+  source:
+    persistentVolumeClaimName: ${SYSPREP_DV_NAME}
+EOF
 
-create_sysprep_datasource
-create_unattend_configmap
-create_oobe_vm
-
-if ! wait_for_dv_ready; then
-  echo "ERROR: DataVolume clone failed - cannot proceed"
-  exit 1
-fi
-
-if ! wait_for_vm_running; then
-  echo "ERROR: VM failed to start after disk clone"
-  exit 1
-fi
-
-if ! wait_for_desktop; then
-  echo "ERROR: Failed to complete OOBE automatically"
-  exit 1
-fi
-
-STABILIZATION_WAIT=300
-echo "Waiting ${STABILIZATION_WAIT}s for Windows Setup to fully finalize before snapshotting..."
-sleep ${STABILIZATION_WAIT}
-
-echo "Gracefully shutting down Windows before snapshotting..."
-/home/ocp-virt-validation-checkup/virtctl stop "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}"
-
-SHUTDOWN_TIMEOUT=300
-SHUTDOWN_ELAPSED=0
-while [ ${SHUTDOWN_ELAPSED} -lt ${SHUTDOWN_TIMEOUT} ]; do
-  VMI_EXISTS=$(oc get vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null && echo "yes" || echo "no")
-  if [ "${VMI_EXISTS}" == "no" ]; then
-    echo "VM has shut down cleanly"
+echo "Waiting for snapshot to be ready..."
+SNAP_TIMEOUT=300
+SNAP_ELAPSED=0
+while [ ${SNAP_ELAPSED} -lt ${SNAP_TIMEOUT} ]; do
+  READY=$(oc get volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+    -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  if [ "${READY}" == "true" ]; then
+    echo "VolumeSnapshot '${SNAPSHOT_NAME}' is ready"
     break
   fi
-  VMI_PHASE=$(oc get vmi "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-    -o jsonpath='{.status.phase}' 2>/dev/null || echo "unknown")
-  echo "[${SHUTDOWN_ELAPSED}s] Waiting for VM shutdown... VMI phase: ${VMI_PHASE}"
-  sleep 10
-  SHUTDOWN_ELAPSED=$((SHUTDOWN_ELAPSED + 10))
+  sleep 5
+  SNAP_ELAPSED=$((SNAP_ELAPSED + 5))
 done
 
-if [ ${SHUTDOWN_ELAPSED} -ge ${SHUTDOWN_TIMEOUT} ]; then
-  echo "WARNING: Graceful shutdown timed out, force stopping..."
-  /home/ocp-virt-validation-checkup/virtctl stop "${OOBE_VM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" --force --grace-period 0 2>/dev/null || true
-  sleep 15
-fi
-
-# Step 10: Snapshot the desktop-ready VM
-echo ""
-echo "=== Phase 3: Creating golden image snapshot ==="
-
-if ! create_snapshot; then
-  echo "ERROR: Failed to create snapshot"
+if [ "${READY}" != "true" ]; then
+  echo "ERROR: Timeout waiting for snapshot"
   exit 1
 fi
 
 # Step 11: Create the final DataSource
-if ! create_datasource; then
-  echo "ERROR: Failed to create DataSource"
-  exit 1
-fi
+echo "Creating DataSource '${GOLDEN_IMAGE_NAME}' from snapshot..."
+oc delete datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataSource
+metadata:
+  name: ${GOLDEN_IMAGE_NAME}
+  labels:
+    app: ocp-virt-validation
+spec:
+  source:
+    snapshot:
+      name: ${SNAPSHOT_NAME}
+      namespace: ${GOLDEN_IMAGE_NAMESPACE}
+EOF
 
-# Step 12: Cleanup temporary resources and SA permissions (traps handle both)
+# Cleanup
 trap - EXIT
-cleanup_oobe_resources
 cleanup_pipeline_sa
+cleanup_autounattend_cm
 
 echo ""
-echo "=== Windows Golden Image Setup Complete ==="
+echo "=== Windows Server 2022 Golden Image Setup Complete ==="
 echo "DataSource: ${GOLDEN_IMAGE_NAME} (namespace: ${GOLDEN_IMAGE_NAMESPACE})"
 echo "Snapshot:   ${SNAPSHOT_NAME}"
 echo ""
-echo "New VMs from this DataSource will boot directly to the Windows desktop."
-echo "Login: Admin / Admin123!"
+echo "Login: Administrator / Heslo123"
+echo "SSH:   Enabled on port 22"


### PR DESCRIPTION
Switching to Windows Server 2022 because it's more stable and predictable for testing - no consumer background noise, no forced updates, simpler OOBE. 
The tier3 storage tests already target win2k22 and use the same credentials as the QE images, so this aligns the golden image with what we actually run against.

Also simplified from the two-phase pipeline+OOBE approach to a single-phase custom autounattend that handles everything in one go (OS install, OpenSSH, firewall, shutdown).

Tested on test-gcnv15 - boots to desktop, SSH works, guest agent reports, all good.