### PR TITLE
feat: add Windows Server 2022 support into the self-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,52 +248,89 @@ $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e DRY_RU
 
 ### Windows Testing (Optional)
 
-The validation checkup supports optional Windows VM testing. When enabled, the checkup will:
-1. Create a Windows 11 golden image using the `windows-efi-installer` Tekton pipeline
-2. Run Windows-specific tests from the tier2 test suite
+The validation checkup supports optional Windows VM testing. There are two options:
 
-#### Prerequisites for Windows Testing
-- **OpenShift Pipelines operator** must be installed on the cluster
-- **Internet access** is required to download the Windows ISO and fetch the pipeline from Artifact Hub (see [Disconnected Environments](#disconnected-environments) for air-gapped clusters)
-- **Sufficient storage** for the Windows golden image (~64GB recommended)
+#### Option 1: Customer-Managed (Apply Manifest)
 
-#### Enabling Windows Testing
-To enable Windows testing, set the `ACCEPT_WINDOWS_EULA` environment variable to `true`:
+A ready-to-use manifest is provided that creates a Windows Server 2022 golden image from scratch using a Tekton pipeline. It includes namespace, RBAC, sysprep configuration, and a PipelineRun — single `oc apply`, full automation.
+
+**Prerequisites:**
+- **OpenShift Pipelines operator** must be installed
+- **cluster-admin** access (for privileged SCC assignment)
+- **Internet access** to download the Windows ISO and fetch the pipeline from Artifact Hub (see [`disconnected/README.md`](disconnected/README.md) for air-gapped setups)
+- **Sufficient storage** (~64GB recommended for the Windows image)
+
+**Setup:**
+
+1. Apply the manifest:
+```bash
+oc apply -f manifests/windows/golden-image.yaml
+```
+2. Wait for the pipeline to complete (~1-2 hours):
+```bash
+oc get pipelinerun -n validation-os-images -w
+```
+3. Verify the DataSource is Ready:
+```bash
+oc get datasource win2k22 -n validation-os-images -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+4. Run the tool normally (no `ACCEPT_WINDOWS_EULA` needed):
+```bash
+podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} ${OCP_VIRT_VALIDATION_IMAGE} generate | oc apply -f -
+```
+
+The tool detects the existing DataSource and runs Windows tests automatically. After tests complete, **nothing is deleted** — your resources remain for future runs.
+
+The manifest also includes a commented-out alternative (Method 2) for users who already have a prepared Windows image and want to import via HTTP, registry, or upload.
+
+See [`manifests/windows/golden-image.yaml`](manifests/windows/golden-image.yaml) for full details and image requirements.
+
+#### Option 2: Automated (Tool Creates Everything)
+
+The tool downloads a Windows Server 2022 ISO, runs a Tekton pipeline to install it, and creates all resources. Everything is cleaned up after tests finish.
+
+**Prerequisites:**
+- **OpenShift Pipelines operator** must be installed
+- **Internet access** to download the ISO and fetch the pipeline from Artifact Hub
+- **Sufficient storage** (~64GB recommended)
+- **`STORAGE_CLASS`** set to a valid storage class (required by the Windows setup script)
+
+**Usage:**
 ```bash
 $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
     -e ACCEPT_WINDOWS_EULA=true \
+    -e STORAGE_CLASS=<your-storage-class> \
     ${OCP_VIRT_VALIDATION_IMAGE} generate
 ```
 
 **Note:** By setting `ACCEPT_WINDOWS_EULA=true`, you acknowledge acceptance of Microsoft's End User License Agreement for Windows.
 
-#### Optional Windows Parameters
+**Optional Parameters:**
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
 | `ACCEPT_WINDOWS_EULA` | Enable Windows testing (must be `true` to enable) | `false` |
-| `WIN_IMAGE_DOWNLOAD_URL` | Custom Windows 11 ISO download URL | Default Microsoft URL |
-| `WIN_IMAGE_NAME` | Name of an existing Windows DataSource to use (skips golden image creation) | _(none)_ |
+| `WIN_IMAGE_DOWNLOAD_URL` | Custom Windows Server 2022 ISO download URL | Default Microsoft URL |
 | `TEKTON_PIPELINE_VERSION` | Version of the `windows-efi-installer` pipeline | `>=v4.21.0` |
 
 Example with custom ISO URL:
 ```bash
 $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
     -e ACCEPT_WINDOWS_EULA=true \
-    -e WIN_IMAGE_DOWNLOAD_URL="https://my-internal-server/windows11.iso" \
+    -e STORAGE_CLASS=<your-storage-class> \
+    -e WIN_IMAGE_DOWNLOAD_URL="https://my-internal-server/SERVER_EVAL_x64FRE_en-us.iso" \
     ${OCP_VIRT_VALIDATION_IMAGE} generate
 ```
 
-#### How It Works
-When Windows testing is enabled:
+**How It Works:**
 1. The checkup verifies that the OpenShift Pipelines operator is installed
-2. A Windows 11 golden image is created in the `openshift-virtualization-os-images` namespace using the `windows-efi-installer` Tekton pipeline (fetched automatically via the hub resolver)
-3. The tier2 test suite includes Windows-specific tests marked with `@pytest.mark.windows`
-4. The golden image is reused for subsequent runs if it already exists
+2. Creates the `validation-os-images` namespace, RBAC, and runs the `windows-efi-installer` Tekton pipeline
+3. The pipeline downloads the ISO and installs Windows Server 2022 with OpenSSH, QEMU guest agent, and firewall disabled
+4. A DataSource (`win2k22`) is created backed by the output PVC
+5. The tier2 test suite runs tests matching `@pytest.mark.conformance`; when no golden image is available, tests with `@pytest.mark.windows` are excluded
+6. After tests complete, the entire `validation-os-images` namespace is deleted
 
-**Note:** The initial Windows image creation takes approximately 60-90 minutes. Subsequent runs will skip this step if the golden image already exists.
-
-**Note:** Windows-specific tests require the `@pytest.mark.windows` marker to be added to the [openshift-virtualization-tests](https://github.com/RedHatQE/openshift-virtualization-tests) repository. Until then, enabling Windows testing will prepare the golden image but no Windows-specific tests will run.
+**Note:** The initial Windows image creation takes approximately 1-2 hours (up to 3 hours on slow networks).
 
 ## Disconnected Environments
 The validation checkup can be run on disconnected (air-gapped) OpenShift clusters by mirroring the required test images to an accessible registry and configuring mirror sets (ITMS + IDMS). No changes to the checkup configuration are needed -- mirror sets transparently redirect image pulls at the CRI-O level.

--- a/disconnected/README.md
+++ b/disconnected/README.md
@@ -350,22 +350,26 @@ The script will:
 
 Windows testing requires additional setup in disconnected environments because the `windows-efi-installer` Tekton pipeline normally uses the hub resolver to fetch the pipeline and tasks from Artifact Hub, which requires internet access.
 
+**Recommended:** Apply `manifests/windows/golden-image.yaml` once. Pre-install the Tekton pipeline (see Step 2 below), set `winImageDownloadURL` to your internal ISO mirror in the manifest, and wait for the pipeline to finish. Then run the checkup **without** `ACCEPT_WINDOWS_EULA` — the tool detects the existing DataSource and skips the pipeline entirely, avoiding repeated downloads and rebuilds.
+
+The steps below describe the **alternative (ephemeral)** path using `ACCEPT_WINDOWS_EULA=true`, which rebuilds the golden image on every run.
+
 ### Prerequisites for Disconnected Windows Testing
 
 1. **OpenShift Pipelines operator** installed on the cluster
-2. **Windows 11 ISO** available on an accessible internal server
+2. **Windows Server 2022 ISO** available on an accessible internal server
 3. **Tekton pipeline and tasks** pre-installed manually
 
-### Step 1: Download the Windows ISO
+### Step 1: Download the Windows Server 2022 ISO
 
-Download the Windows 11 ISO from Microsoft on a connected machine and host it on an internal HTTP server accessible from the cluster:
+Download the Windows Server 2022 evaluation ISO from Microsoft on a connected machine and host it on an internal HTTP server accessible from the cluster:
 
 ```bash
 # On connected machine
-curl -L -o windows11.iso "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENT_CONSUMER_x64FRE_en-us.iso"
+curl -L -o SERVER_EVAL_x64FRE_en-us.iso "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
 
 # Copy to your internal HTTP server
-scp windows11.iso user@internal-server:/var/www/html/images/
+scp SERVER_EVAL_x64FRE_en-us.iso user@internal-server:/var/www/html/images/
 ```
 
 ### Step 2: Pre-install the Tekton Pipeline
@@ -387,10 +391,12 @@ curl -L -o windows-efi-installer-configmaps.yaml \
 
 Transfer and apply to the disconnected cluster:
 ```bash
-# Apply to the golden image namespace
-oc apply -f windows-efi-installer-tasks.yaml -n openshift-virtualization-os-images
-oc apply -f windows-efi-installer-configmaps.yaml -n openshift-virtualization-os-images
-oc apply -f windows-efi-installer.yaml -n openshift-virtualization-os-images
+oc create namespace validation-os-images
+oc label namespace validation-os-images app=ocp-virt-validation
+oc label namespace validation-os-images pod-security.kubernetes.io/enforce=privileged
+oc apply -f windows-efi-installer-tasks.yaml -n validation-os-images
+oc apply -f windows-efi-installer-configmaps.yaml -n validation-os-images
+oc apply -f windows-efi-installer.yaml -n validation-os-images
 ```
 
 Alternatively, get the manifests from Artifact Hub:
@@ -403,13 +409,14 @@ When running the validation checkup, specify your internal Windows ISO URL:
 ```bash
 $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
     -e ACCEPT_WINDOWS_EULA=true \
-    -e WIN_IMAGE_DOWNLOAD_URL="http://internal-server.example.com/images/windows11.iso" \
+    -e STORAGE_CLASS=<your-storage-class> \
+    -e WIN_IMAGE_DOWNLOAD_URL="http://internal-server.example.com/images/SERVER_EVAL_x64FRE_en-us.iso" \
     ${OCP_VIRT_VALIDATION_IMAGE} generate
 ```
 
 ### Notes for Disconnected Windows Testing
 
-- The Windows golden image will be created in the `openshift-virtualization-os-images` namespace
-- The image creation takes approximately 60-90 minutes on first run
-- Once created, the golden image is reused for subsequent test runs
+- The pipeline output PVC backs a `win2k22` DataSource in a custom `validation-os-images` namespace created by the tool -- no intermediate VMs or snapshots
+- The image creation takes approximately 1-2 hours on first run (up to 3 hours on slow networks)
+- With `ACCEPT_WINDOWS_EULA=true`, each run rebuilds the golden image from scratch and cleans up on completion
 - If the hub resolver fails (due to no internet), the checkup will provide instructions for manual pipeline installation

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -20,7 +20,6 @@ STORAGE_CLASS=${STORAGE_CLASS:-""}
 STORAGE_CAPABILITIES=${STORAGE_CAPABILITIES:-""}
 ACCEPT_WINDOWS_EULA=${ACCEPT_WINDOWS_EULA:-"false"}
 WIN_IMAGE_DOWNLOAD_URL=${WIN_IMAGE_DOWNLOAD_URL:-""}
-WIN_IMAGE_NAME=${WIN_IMAGE_NAME:-""}
 TEKTON_PIPELINE_VERSION=${TEKTON_PIPELINE_VERSION:-""}
 
 # Calculate storage size based on test suites (2Gi per suite, 10Gi for tier2)
@@ -224,8 +223,6 @@ spec:
               value: "${ACCEPT_WINDOWS_EULA}"
             - name: WIN_IMAGE_DOWNLOAD_URL
               value: "${WIN_IMAGE_DOWNLOAD_URL}"
-            - name: WIN_IMAGE_NAME
-              value: "${WIN_IMAGE_NAME}"
             - name: TEKTON_PIPELINE_VERSION
               value: "${TEKTON_PIPELINE_VERSION}"
           volumeMounts:

--- a/manifests/windows/golden-image.yaml
+++ b/manifests/windows/golden-image.yaml
@@ -1,0 +1,414 @@
+# Windows Server 2022 Golden Image Setup
+#
+# This manifest creates a ready-to-use Windows Server 2022 golden image
+# for the self-validation tool. Pick ONE of the methods below:
+#
+#   Method 1 (default): Tekton pipeline — installs Windows from ISO,
+#     configures SSH, guest agent, Administrator/Administrator via sysprep.
+#     Full automation.
+#
+#   Method 2: DataVolume import — use if you already have a prepared
+#     Windows image (HTTP URL, container registry, or existing PVC).
+#
+# Prerequisites:
+#   - Method 1: OpenShift Pipelines operator + cluster-admin
+#   - Method 2: A prepared Windows image with SSH, guest agent, Administrator/Administrator
+#
+# Usage:
+#   1. Choose your method (see comments below)
+#   2. Apply: oc apply -f manifests/windows/golden-image.yaml
+#   3. Wait:
+#      - Method 1: oc get pipelinerun -n validation-os-images -w (~1-2 hours)
+#      - Method 2: oc get dv win2k22 -n validation-os-images -w
+#   4. Verify it's ready (should print "True"):
+#      oc get datasource win2k22 -n validation-os-images -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+#   5. Run the validation tool
+#
+# Cleanup (if deleting the namespace):
+#   oc delete namespace validation-os-images
+#   oc delete clusterrolebinding validation-pipeline-privileged-scc
+#
+# To retry after pipeline failure:
+#   oc delete pipelinerun win2022-install -n validation-os-images
+#   oc apply -f manifests/windows/golden-image.yaml
+#
+# The resulting image will have:
+#   - OpenSSH server enabled (port 22)
+#   - Administrator password: Administrator
+#   - QEMU guest agent installed
+#   - EFI boot with vTPM support
+#   - Windows Firewall disabled
+#
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: validation-os-images
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: os-images.kubevirt.io:view
+  namespace: validation-os-images
+rules:
+- apiGroups: [""]
+  resources: [persistentvolumeclaims, persistentvolumeclaims/status]
+  verbs: [get, list, watch]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshots, volumesnapshots/status]
+  verbs: [get, list, watch]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datavolumes]
+  verbs: [get, list, watch]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datavolumes/source]
+  verbs: [create]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datasources]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: os-images.kubevirt.io:view
+  namespace: validation-os-images
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: os-images.kubevirt.io:view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts
+---
+# =============================================================================
+# METHOD 1: Tekton Pipeline (default)
+#
+# Installs Windows from ISO with our sysprep. Creates everything from scratch.
+# Requires: OpenShift Pipelines operator, cluster-admin.
+#
+# If using Method 2 instead, comment out or delete this entire section
+# (ServiceAccount, RoleBindings, ConfigMap, PipelineRun).
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+  namespace: validation-os-images
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-edit
+  namespace: validation-os-images
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+  namespace: validation-os-images
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: validation-pipeline-privileged-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+  namespace: validation-os-images
+---
+# NOTE: Keep autounattend.xml and post-update.ps1 in sync with
+# scripts/windows/setup-golden-image.sh (create_autounattend_configmap function)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: win2k22-autounattend
+  namespace: validation-os-images
+data:
+  autounattend.xml: |
+    <?xml version="1.0" encoding="utf-8"?>
+    <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <SetupUILanguage>
+            <UILanguage>en-US</UILanguage>
+          </SetupUILanguage>
+          <InputLocale>0409:00000409</InputLocale>
+          <SystemLocale>en-US</SystemLocale>
+          <UILanguage>en-US</UILanguage>
+          <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <DriverPaths>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+              <Path>E:\</Path>
+            </PathAndCredentials>
+          </DriverPaths>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <DiskConfiguration>
+            <WillShowUI>Never</WillShowUI>
+            <Disk wcm:action="add">
+              <CreatePartitions>
+                  <CreatePartition wcm:action="add">
+                      <Order>1</Order>
+                      <Type>EFI</Type>
+                      <Size>100</Size>
+                  </CreatePartition>
+                  <CreatePartition wcm:action="add">
+                      <Order>2</Order>
+                      <Type>MSR</Type>
+                      <Size>16</Size>
+                  </CreatePartition>
+                  <CreatePartition wcm:action="add">
+                      <Order>3</Order>
+                      <Type>Primary</Type>
+                      <Extend>true</Extend>
+                  </CreatePartition>
+              </CreatePartitions>
+              <ModifyPartitions>
+                <ModifyPartition wcm:action="add">
+                    <Order>1</Order>
+                    <PartitionID>1</PartitionID>
+                    <Label>EFI</Label>
+                    <Format>FAT32</Format>
+                </ModifyPartition>
+                <ModifyPartition wcm:action="add">
+                    <Order>2</Order>
+                    <PartitionID>3</PartitionID>
+                    <Label>Windows</Label>
+                    <Letter>C</Letter>
+                    <Format>NTFS</Format>
+                </ModifyPartition>
+              </ModifyPartitions>
+              <DiskID>0</DiskID>
+              <WillWipeDisk>true</WillWipeDisk>
+            </Disk>
+          </DiskConfiguration>
+          <ImageInstall>
+            <OSImage>
+              <InstallFrom>
+                <MetaData wcm:action="add">
+                  <Key>/Image/Index</Key>
+                  <Value>2</Value>
+                </MetaData>
+              </InstallFrom>
+              <InstallTo>
+                <DiskID>0</DiskID>
+                <PartitionID>3</PartitionID>
+              </InstallTo>
+            </OSImage>
+          </ImageInstall>
+          <UserData>
+            <AcceptEula>true</AcceptEula>
+          </UserData>
+        </component>
+      </settings>
+      <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <InputLocale>0409:00000409</InputLocale>
+          <SystemLocale>en-US</SystemLocale>
+          <UILanguage>en-US</UILanguage>
+          <UILanguageFallback>en-US</UILanguageFallback>
+          <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <UserAccounts>
+            <AdministratorPassword>
+              <Value>Administrator</Value>
+              <PlainText>true</PlainText>
+            </AdministratorPassword>
+          </UserAccounts>
+          <AutoLogon>
+            <Enabled>true</Enabled>
+            <Password>
+              <Value>Administrator</Value>
+              <PlainText>true</PlainText>
+            </Password>
+            <Username>Administrator</Username>
+          </AutoLogon>
+          <TimeZone>UTC</TimeZone>
+          <OOBE>
+            <HideEULAPage>true</HideEULAPage>
+            <HideLocalAccountScreen>true</HideLocalAccountScreen>
+            <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+            <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+            <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+            <NetworkLocation>Work</NetworkLocation>
+            <ProtectYourPC>3</ProtectYourPC>
+          </OOBE>
+          <FirstLogonCommands>
+            <SynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile F:\post-update.ps1</CommandLine>
+              <Description>Install SSH and configure system</Description>
+            </SynchronousCommand>
+          </FirstLogonCommands>
+        </component>
+      </settings>
+    </unattend>
+  post-update.ps1: |
+    try {
+      $ErrorActionPreference = 'Stop'
+
+      # Install QEMU guest agent
+      Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+      # Install and start OpenSSH server
+      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+      Set-Service -Name sshd -StartupType Automatic
+      Start-Service sshd
+
+      # Disable Windows Firewall entirely
+      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+      $ErrorActionPreference = 'Continue'
+
+      # Suppress network location wizard and set profile
+      New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
+      Set-NetConnectionProfile -InterfaceAlias "Ethernet" -NetworkCategory Private -ErrorAction SilentlyContinue
+
+      # Disable Server Manager auto-launch
+      Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Value 1
+
+      # Cleanup for smaller image
+      Vssadmin delete shadows /all /quiet 2>$null
+      Remove-Item -Path $env:Temp -Recurse -Force -ErrorAction SilentlyContinue
+      powercfg -h off 2>$null
+
+      $dismJob = Start-Job { dism.exe /online /Cleanup-Image /StartComponentCleanup }
+      if (-not (Wait-Job $dismJob -Timeout 300)) {
+        Stop-Job $dismJob
+        Remove-Job $dismJob -Force
+      } else {
+        Remove-Job $dismJob
+      }
+
+      if (Test-Path "C:\Windows\Panther\unattend.xml") {
+        Rename-Item "C:\Windows\Panther\unattend.xml" "C:\Windows\Panther\unattend.install.xml"
+      }
+
+      try { (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject") } catch {}
+    }
+    finally {
+      Stop-Service wuauserv -Force -ErrorAction SilentlyContinue
+      Set-Service wuauserv -StartupType Disabled -ErrorAction SilentlyContinue
+      Stop-Computer -Force
+    }
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: win2022-install
+  namespace: validation-os-images
+spec:
+  timeouts:
+    pipeline: "3h"
+  pipelineRef:
+    resolver: hub
+    params:
+      - name: catalog
+        value: redhat-pipelines
+      - name: type
+        value: artifact
+      - name: kind
+        value: pipeline
+      - name: name
+        value: windows-efi-installer
+      - name: version
+        value: ">=v4.21.0"
+  params:
+    - name: winImageDownloadURL
+      # EDIT: Windows ISO URL. Default is Microsoft evaluation ISO.
+      # Replace with your own ISO URL or internal mirror if needed.
+      value: "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
+    - name: acceptEula
+      value: "true"
+    - name: baseDvName
+      value: "win2k22"
+    - name: baseDvNamespace
+      value: "validation-os-images"
+    - name: instanceTypeName
+      value: "u1.large"
+    - name: instanceTypeKind
+      value: "VirtualMachineClusterInstancetype"
+    - name: preferenceName
+      value: "windows.2k22"
+    - name: autounattendConfigMapName
+      value: "win2k22-autounattend"
+    - name: isoDVName
+      value: "win2k22-iso"
+    # Optional: Set storage class. If omitted, the cluster default is used.
+    # - name: baseDvStorageClass
+    #   value: "my-storage-class"
+  taskRunSpecs:
+    - pipelineTaskName: modify-windows-iso-file
+      podTemplate:
+        securityContext:
+          fsGroup: 107
+          runAsUser: 107
+---
+# =============================================================================
+# METHOD 2: DataVolume Import (alternative)
+#
+# Use this INSTEAD of Method 1 if you already have a prepared Windows image.
+# Your image must already have SSH, guest agent, Administrator/Administrator configured.
+#
+# To use: Delete or comment out the Method 1 section above (ServiceAccount,
+# RoleBindings, ConfigMap, PipelineRun), then uncomment the DataVolume below.
+# =============================================================================
+#
+# apiVersion: cdi.kubevirt.io/v1beta1
+# kind: DataVolume
+# metadata:
+#   name: win2k22
+#   namespace: validation-os-images
+# spec:
+#   source:
+#     # --- Option A: HTTP URL ---
+#     http:
+#       url: "https://my-server.example.com/win2k22.qcow2"
+#
+#     # --- Option B: Container registry ---
+#     # registry:
+#     #   url: "docker://registry.example.com/images/win2k22:latest"
+#
+#     # --- Option C: Clone from existing PVC ---
+#     # pvc:
+#     #   name: my-windows-pvc
+#     #   namespace: my-namespace
+#
+#     # --- Option D: Upload from local file ---
+#     # (apply first, then run: virtctl image-upload dv win2k22 -n validation-os-images --image-path=./win2k22.qcow2)
+#     # upload: {}
+#
+#   storage:
+#     resources:
+#       requests:
+#         storage: 60Gi
+#     # storageClassName: my-storage-class
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataSource
+metadata:
+  name: win2k22
+  namespace: validation-os-images
+spec:
+  source:
+    pvc:
+      name: win2k22
+      namespace: validation-os-images

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,6 +6,9 @@ readonly SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 source "${SCRIPT_DIR}/funcs.sh"
 TEST_KUBEVIRT_SCRIPT="${SCRIPT_DIR}/kubevirt/test-kubevirt.sh"
 
+export GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
+export GOLDEN_IMAGE_NAME="${GOLDEN_IMAGE_NAME:-win2k22}"
+
 create_kubeconfig
 
 # Add owner reference to PVC so it gets cleaned up when the job is deleted
@@ -181,6 +184,17 @@ CURRENT_TEST_PID=""
 # Progress watcher PID (will be started later after storage config is set)
 PROGRESS_WATCHER_PID=""
 
+# Cleanup Windows golden image resources.
+# Only clean up what the current run created.
+# EULA gate: if this run didn't create the namespace, don't touch it.
+# Label gate: if the namespace isn't tool-labeled, it belongs to the user (BYOI).
+cleanup_windows_resources() {
+    if [ "${ACCEPT_WINDOWS_EULA}" != "true" ]; then
+        return
+    fi
+    cleanup_golden_image_resources "${GOLDEN_IMAGE_NAMESPACE}"
+}
+
 # Function to cleanup progress watcher and forward signals
 cleanup_and_forward_signal() {
     echo "Entrypoint received termination signal, cleaning up..."
@@ -202,6 +216,8 @@ cleanup_and_forward_signal() {
         wait "${PROGRESS_WATCHER_PID}" 2>/dev/null || true
         echo "Progress watcher stopped."
     fi
+
+    cleanup_windows_resources
     
     exit 1
 }
@@ -387,19 +403,20 @@ fi
 # ======================
 # Windows Golden Image Setup
 # ======================
-if [ "${ACCEPT_WINDOWS_EULA}" == "true" ]; then
-  echo "Setting up Windows golden image for Windows tests..."
-  WINDOWS_SETUP_SCRIPT="${SCRIPT_DIR}/windows/setup-golden-image.sh"
-  if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
-    # Export variables needed by the Windows setup script
-    export STORAGE_CLASS
-    export WIN_IMAGE_DOWNLOAD_URL
-    export WIN_IMAGE_NAME
-    export TEKTON_PIPELINE_VERSION
-    export ACCEPT_WINDOWS_EULA
-    bash "${WINDOWS_SETUP_SCRIPT}"
-  else
-    echo "Warning: Windows setup script not found at ${WINDOWS_SETUP_SCRIPT}"
+# Run the Windows setup script which handles both paths:
+#   - BYOI: DataSource exists and is Ready → exits immediately
+#   - Tool-created: ACCEPT_WINDOWS_EULA=true → runs pipeline
+WINDOWS_SETUP_SCRIPT="${SCRIPT_DIR}/windows/setup-golden-image.sh"
+if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
+  export STORAGE_CLASS
+  export WIN_IMAGE_DOWNLOAD_URL
+  export TEKTON_PIPELINE_VERSION
+  export ACCEPT_WINDOWS_EULA
+  if ! bash "${WINDOWS_SETUP_SCRIPT}"; then
+    echo "WARNING: Windows golden image setup failed. Windows tests will be skipped."
+    echo "All other test suites will continue normally."
+    cleanup_windows_resources
+    unset ACCEPT_WINDOWS_EULA
   fi
 fi
 
@@ -499,6 +516,11 @@ if [ -d "${RESULTS_DIR}/.dry-run" ]; then
     echo "Cleaning up .dry-run directory..."
     rm -rf "${RESULTS_DIR}/.dry-run"
 fi
+
+# ================================
+# Windows Golden Image Cleanup
+# ================================
+cleanup_windows_resources
 
 # =========
 # Summarize

--- a/scripts/funcs.sh
+++ b/scripts/funcs.sh
@@ -326,3 +326,37 @@ get_virtctl() {
   rm virtctl.tar.gz
   echo "virtctl downloaded"
 }
+
+# Cleanup golden image resources (namespace, SCC policy, ClusterRoleBinding).
+# When the namespace is tool-managed (labeled app=ocp-virt-validation), deletes
+# the entire namespace. Otherwise, optionally cleans up individual labeled resources.
+#
+# Arguments:
+#   $1 - namespace to clean up
+#   $2 - if "selective", clean up individual labeled resources when namespace
+#        is not tool-managed (default: skip cleanup for non-tool-managed namespaces)
+cleanup_golden_image_resources() {
+  local ns="$1"
+  local mode="${2:-}"
+
+  local ns_label
+  ns_label="$(oc get namespace "${ns}" -o jsonpath='{.metadata.labels.app}' 2>/dev/null || true)"
+
+  if [ "${ns_label}" == "ocp-virt-validation" ]; then
+    echo "Cleaning up tool-managed namespace ${ns}..."
+    oc delete namespace "${ns}" --wait=false 2>/dev/null || true
+    oc adm policy remove-scc-from-user privileged -z pipeline -n "${ns}" 2>/dev/null || true
+    oc delete clusterrolebinding -l app=ocp-virt-validation 2>/dev/null || true
+  elif [ "${mode}" == "selective" ]; then
+    echo "Namespace ${ns} is not tool-managed, cleaning up individual labeled resources only"
+    oc delete datasource -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete pvc -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete pipelinerun -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete configmap -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete rolebinding -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete role -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+    oc delete sa -l app=ocp-virt-validation -n "${ns}" 2>/dev/null || true
+  else
+    return 0
+  fi
+}

--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+readonly SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+source "${SCRIPT_DIR}/../funcs.sh"
+
 function cleanup_test_namespaces() {
     echo "Cleaning up tier2 test namespaces..."
     for ns in cnv-tests-run-in-progress-ns cnv-tests-utilities; do
@@ -198,32 +201,63 @@ if [ -n "${K_EXPR}" ]; then
 fi
 
 # Build pytest marker expression
-# Note: Windows tests require @pytest.mark.windows marker in openshift-virtualization-tests
-# When Windows tests are added with this marker, they will be automatically included
-# when ACCEPT_WINDOWS_EULA=true
+# Runs tests matching @pytest.mark.conformance; when no golden image is available,
+# tests with @pytest.mark.windows are excluded.
+# A golden image is available when either:
+# - ACCEPT_WINDOWS_EULA=true (tool creates golden image), or
+# - A user-provided (BYOI) DataSource exists and is Ready
+# A tool-labeled DataSource (app=ocp-virt-validation) without ACCEPT_WINDOWS_EULA
+# is treated as stale from a previous run and cleaned up, not reused as BYOI.
 MARKERS="conformance"
 WIN_IMAGE_FLAG=""
-if [ "${ACCEPT_WINDOWS_EULA}" == "true" ]; then
-  echo "Windows EULA accepted - Windows tests will be included when available"
-  MARKERS="${MARKERS} or windows"
-  # WIN_USERNAME/WIN_PASSWORD: defaults match setup-golden-image.sh output (Administrator/Heslo123),
-  # but can be overridden for custom golden images with different credentials
-  WIN_IMAGE_FLAG="--tc=win_golden_image_name:${WIN_IMAGE_NAME:-windows2022-golden-image} --tc=os_login_param.win.username:${WIN_USERNAME:-Administrator} --tc=os_login_param.win.password:${WIN_PASSWORD:-Heslo123} --tc=storage_class_a:${STORAGE_CLASS} --tc=storage_class_b:${STORAGE_CLASS}"
+GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
+GOLDEN_IMAGE_NAME="${GOLDEN_IMAGE_NAME:-win2k22}"
+DS_READY="$(oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+DS_LABEL="$(oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+  -o jsonpath='{.metadata.labels.app}' 2>/dev/null || true)"
+if [ "${DS_LABEL}" == "ocp-virt-validation" ] && [ "${ACCEPT_WINDOWS_EULA}" != "true" ]; then
+  echo "WARNING: Found stale tool-managed DataSource from a previous run. Cleaning up..."
+  cleanup_golden_image_resources "${GOLDEN_IMAGE_NAMESPACE}" selective
+  DS_READY=""
+fi
+if [ "${ACCEPT_WINDOWS_EULA}" == "true" ] || \
+   { [ "${DS_READY}" == "True" ] && [ "${DS_LABEL}" != "ocp-virt-validation" ]; }; then
+  echo "Windows golden image available - Windows tests will be included"
+  WIN_LOGIN_CONFIG="${ARTIFACTS}/win_login_config.py"
+  cat > "${WIN_LOGIN_CONFIG}" <<PYEOF
+os_login_param = {
+    "win-container-disk": {
+        "username": "Administrator",
+        "password": "Administrator",
+    },
+}
+
+config = globals().get("config") or {}
+config["os_login_param"] = os_login_param
+PYEOF
+  WIN_IMAGE_FLAG="--tc-file=${WIN_LOGIN_CONFIG} --tc=win_golden_image_name:${GOLDEN_IMAGE_NAME}"
+else
+  MARKERS="conformance and not windows"
 fi
 
 echo "Starting tier2 tests 🧪"
 echo "Using markers: ${MARKERS}"
+
+# TODO: Remove --skip-artifactory-check before GA once openshift-virtualization-tests
+# removes the unconditional artifactory dependency from session-scoped fixtures.
 
 if [ "${DRY_RUN}" == "true" ]; then
   # In dry-run mode, collect tests and generate a proper JUnit XML with all
   # testcase elements -- aligned with how Ginkgo's --ginkgo.dry-run works.
   (set +e; .venv/bin/pytest \
     -m "${MARKERS}" \
-    -W "ignore::pytest.PytestRemovedIn10Warning" \
     --skip-artifactory-check \
     --latest-rhel \
     --tc=hco_subscription:${SUBSCRIPTION_NAME} \
     --conformance-storage-class=${STORAGE_CLASS} \
+    --tc=storage_class_a:${STORAGE_CLASS} \
+    --tc=storage_class_b:${STORAGE_CLASS} \
     ${STORAGE_CLASS_CONFIG} \
     ${HCP_FLAG} \
     ${WIN_IMAGE_FLAG} \
@@ -236,6 +270,9 @@ if [ "${DRY_RUN}" == "true" ]; then
   wait ${TEST_PID} || true
 
   # Generate JUnit XML from collected test IDs, accounting for TEST_SKIPS
+  # Overwrite .exit_code after successful JUnit generation so junit_parser
+  # does not flag the suite as a setup failure when pytest --collect-only
+  # exits non-zero (e.g. import warnings in CI or no tests collected).
   .venv/bin/python -c "
 import subprocess, sys, socket
 from xml.etree.ElementTree import Element, SubElement, ElementTree
@@ -259,7 +296,7 @@ test_ids = [l.strip() for l in lines if '::' in l and not l.startswith(('=', '-'
 skipped_count = 0
 if skip_entries:
     result = subprocess.run(
-        ['.venv/bin/pytest', '--collect-only', '-q', '-m', 'conformance'],
+        ['.venv/bin/pytest', '--collect-only', '-q', '-m', '${MARKERS}'],
         capture_output=True, text=True
     )
     all_collected = result.stdout
@@ -294,14 +331,19 @@ tree.write(junit_path, xml_declaration=True, encoding='unicode')
 print(f'Generated JUnit XML with {total_tests} test(s) ({len(test_ids)} collected, {skipped_count} skipped via TEST_SKIPS)')
 " "${ARTIFACTS}/tier2-log.txt" "${ARTIFACTS}/junit.results.xml" "${TEST_SKIPS:-}" "${TEST_FOCUS:-}"
 
+  if [ -f "${ARTIFACTS}/junit.results.xml" ]; then
+    echo 0 > "${ARTIFACTS}/.exit_code"
+  fi
+
 else
   (set +e; .venv/bin/pytest \
     -m "${MARKERS}" \
-    -W "ignore::pytest.PytestRemovedIn10Warning" \
     --skip-artifactory-check \
     --latest-rhel \
     --tc=hco_subscription:${SUBSCRIPTION_NAME} \
     --conformance-storage-class=${STORAGE_CLASS} \
+    --tc=storage_class_a:${STORAGE_CLASS} \
+    --tc=storage_class_b:${STORAGE_CLASS} \
     ${STORAGE_CLASS_CONFIG} \
     ${HCP_FLAG} \
     ${WIN_IMAGE_FLAG} \
@@ -333,7 +375,7 @@ skip_entries = [e for e in skip_entries if e not in focus_entries]
 
 # Collect all conformance test node IDs (without running them)
 result = subprocess.run(
-    ['.venv/bin/pytest', '--collect-only', '-q', '-m', 'conformance'],
+    ['.venv/bin/pytest', '--collect-only', '-q', '-m', '${MARKERS}'],
     capture_output=True, text=True
 )
 collected = result.stdout

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -4,15 +4,16 @@
 #
 # Creates a ready-to-use Windows Server 2022 golden image using the
 # windows-efi-installer Tekton pipeline with a custom autounattend.
-# The resulting DataSource produces VMs that boot directly to the desktop
-# with OpenSSH enabled and firewall disabled — no manual setup needed.
+# The pipeline output PVC backs a DataSource in a custom namespace
+# (validation-os-images), which is created and owned by this tool.
 #
 # Flow:
-#   1. Pipeline downloads the ISO and injects our custom autounattend.xml
-#   2. VM boots and installs Windows Server 2022 (Desktop Experience)
-#   3. FirstLogonCommands run post-update.ps1 (guest agent, OpenSSH, firewall, cleanup)
-#   4. VM shuts down automatically after configuration
-#   5. Snapshot the disk and create a DataSource (this is the golden image)
+#   1. Create the validation-os-images namespace
+#   2. Pipeline downloads the ISO and injects our custom autounattend.xml
+#   3. Pipeline creates a PVC and boots a VM that installs Windows Server 2022 onto it
+#   4. FirstLogonCommands run post-update.ps1 (guest agent, OpenSSH, firewall, cleanup)
+#   5. VM shuts down automatically after configuration
+#   6. Create a DataSource pointing to the output PVC
 #
 # Prerequisites:
 # - OpenShift Pipelines operator installed
@@ -21,16 +22,16 @@
 #
 # Optional:
 # - WIN_IMAGE_DOWNLOAD_URL: Custom Windows ISO download URL
-# - WIN_IMAGE_NAME: Custom golden image DataSource name
 # - WIN_INSTANCE_TYPE: Instance type (default: u1.large)
 #
 
 set -e
 
-GOLDEN_IMAGE_NAMESPACE="openshift-virtualization-os-images"
+readonly SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+source "${SCRIPT_DIR}/../funcs.sh"
 
-DEFAULT_WIN_GOLDEN_IMAGE_NAME="windows2022-golden-image"
-GOLDEN_IMAGE_NAME="${WIN_IMAGE_NAME:-${DEFAULT_WIN_GOLDEN_IMAGE_NAME}}"
+GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
+GOLDEN_IMAGE_NAME="${GOLDEN_IMAGE_NAME:-win2k22}"
 
 DEFAULT_WIN_IMAGE_URL="https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
 WIN_IMAGE_URL="${WIN_IMAGE_DOWNLOAD_URL:-${DEFAULT_WIN_IMAGE_URL}}"
@@ -41,46 +42,29 @@ DEFAULT_INSTANCE_TYPE="u1.large"
 INSTANCE_TYPE="${WIN_INSTANCE_TYPE:-${DEFAULT_INSTANCE_TYPE}}"
 
 AUTOUNATTEND_CM_NAME="${GOLDEN_IMAGE_NAME}-autounattend"
-SYSPREP_DV_NAME="${WIN_SYSPREP_PVC:-${GOLDEN_IMAGE_NAME}}"
-SNAPSHOT_NAME="${GOLDEN_IMAGE_NAME}-snap"
-
-VOLUME_SNAPSHOT_CLASS="${VOLUME_SNAPSHOT_CLASS:-}"
 
 # --- Helper Functions ---
 
-detect_snapshot_class() {
-  if [ -n "${VOLUME_SNAPSHOT_CLASS}" ]; then
-    return
-  fi
-  local sc_provisioner
-  sc_provisioner=$(oc get sc "${STORAGE_CLASS}" -o jsonpath='{.provisioner}' 2>/dev/null)
-  if [ -z "${sc_provisioner}" ]; then
-    echo "ERROR: Cannot determine provisioner for StorageClass '${STORAGE_CLASS}'"
-    exit 1
-  fi
-  VOLUME_SNAPSHOT_CLASS=$(oc get volumesnapshotclass -o json 2>/dev/null | \
-    python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for item in data.get('items', []):
-    if item.get('driver') == '${sc_provisioner}':
-        print(item['metadata']['name'])
-        sys.exit(0)
-sys.exit(1)
-" 2>/dev/null)
-  if [ -z "${VOLUME_SNAPSHOT_CLASS}" ]; then
-    echo "ERROR: No VolumeSnapshotClass found for provisioner '${sc_provisioner}'"
-    exit 1
-  fi
-  echo "Auto-detected VolumeSnapshotClass: ${VOLUME_SNAPSHOT_CLASS} (provisioner: ${sc_provisioner})"
-}
-
 cleanup_pipeline_sa() {
   if [ "${CREATED_PIPELINE_SA}" == "true" ]; then
+    # Don't delete SA if pipeline is still running — it needs the SA to complete
+    if [ -n "${PIPELINE_RUN_NAME:-}" ]; then
+      local pr_status
+      pr_status=$(oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || echo "")
+      if [ "${pr_status}" == "Running" ] || [ "${pr_status}" == "ResolvingTaskRef" ]; then
+        echo "Pipeline still running — skipping SA cleanup to avoid disruption."
+        return
+      fi
+    fi
     echo "Cleaning up pipeline service account permissions..."
     oc adm policy remove-scc-from-user privileged -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
     oc adm policy remove-role-from-user edit -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-    oc delete serviceaccount pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+    local SA_LABEL
+    SA_LABEL=$(oc get sa pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" -o jsonpath='{.metadata.labels.app}' 2>/dev/null || echo "")
+    if [ "${SA_LABEL}" == "ocp-virt-validation" ]; then
+      oc delete serviceaccount pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+    fi
   fi
 }
 
@@ -88,6 +72,169 @@ cleanup_autounattend_cm() {
   oc delete configmap "${AUTOUNATTEND_CM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
 }
 
+cleanup_namespace() {
+  cleanup_golden_image_resources "${GOLDEN_IMAGE_NAMESPACE}"
+}
+
+run_pipeline() {
+  CREATED_PIPELINE_SA=false
+  echo "Ensuring pipeline service account exists..."
+  if ! oc get sa pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
+    echo "Creating pipeline service account..."
+    oc create serviceaccount pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+    oc label serviceaccount pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" app=ocp-virt-validation --overwrite
+  fi
+  echo "Granting pipeline service account privileged SCC and edit role..."
+  oc adm policy add-scc-to-user privileged -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
+  CREATED_PIPELINE_SA=true
+  oc adm policy add-role-to-user edit -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
+
+  if [ -z "${STORAGE_CLASS}" ]; then
+    echo "ERROR: STORAGE_CLASS is not set"
+    exit 1
+  fi
+
+  echo "Using storage class: ${STORAGE_CLASS}"
+  echo "Using Windows ISO URL: ${WIN_IMAGE_URL}"
+  echo "Using instance type: ${INSTANCE_TYPE}"
+
+  create_autounattend_configmap
+
+  echo ""
+  echo "=== Running Windows Server 2022 Installation Pipeline ==="
+
+  PIPELINE_RUN_NAME=$(oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -o name -f - <<EOF | cut -d/ -f2
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: win2022-golden-
+  labels:
+    app: ocp-virt-validation
+spec:
+  timeouts:
+    pipeline: "3h"
+  pipelineRef:
+    resolver: hub
+    params:
+      - name: catalog
+        value: redhat-pipelines
+      - name: type
+        value: artifact
+      - name: kind
+        value: pipeline
+      - name: name
+        value: windows-efi-installer
+      - name: version
+        value: "${PIPELINE_VERSION}"
+  params:
+    - name: winImageDownloadURL
+      value: "${WIN_IMAGE_URL}"
+    - name: acceptEula
+      value: "${ACCEPT_WINDOWS_EULA}"
+    - name: baseDvName
+      value: "${GOLDEN_IMAGE_NAME}"
+    - name: baseDvNamespace
+      value: "${GOLDEN_IMAGE_NAMESPACE}"
+    - name: instanceTypeName
+      value: "${INSTANCE_TYPE}"
+    - name: instanceTypeKind
+      value: "VirtualMachineClusterInstancetype"
+    - name: preferenceName
+      value: "windows.2k22"
+    - name: autounattendConfigMapName
+      value: "${AUTOUNATTEND_CM_NAME}"
+    - name: baseDvStorageClass
+      value: "${STORAGE_CLASS}"
+    - name: isoDVName
+      value: "${GOLDEN_IMAGE_NAME}-iso"
+  taskRunSpecs:
+    - pipelineTaskName: modify-windows-iso-file
+      podTemplate:
+        securityContext:
+          fsGroup: 107
+          runAsUser: 107
+EOF
+  )
+
+  if [ -z "${PIPELINE_RUN_NAME}" ]; then
+    echo "ERROR: Failed to create PipelineRun or parse its name"
+    exit 1
+  fi
+
+  echo "Created PipelineRun: ${PIPELINE_RUN_NAME}"
+  echo "Waiting for Windows installation to complete (this may take up to 3 hours)..."
+
+  local TIMEOUT_SECONDS=10800
+  local POLL_INTERVAL=60
+  local ELAPSED=0
+
+  while [ ${ELAPSED} -lt ${TIMEOUT_SECONDS} ]; do
+    local STATUS
+    STATUS=$(oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || echo "Unknown")
+
+    case "${STATUS}" in
+      "Succeeded")
+        echo "Pipeline completed successfully!"
+        break
+        ;;
+      "Failed"|"PipelineRunTimeout"|"TaskRunCancelled"|"CouldntGetPipeline")
+        if [ "${STATUS}" == "CouldntGetPipeline" ]; then
+          echo "ERROR: Failed to fetch pipeline from artifacthub."
+          echo "For disconnected environments, manually install the pipeline first:"
+          echo "  https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer"
+          exit 1
+        fi
+        echo "ERROR: Pipeline failed with status: ${STATUS}"
+        oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o yaml | tail -50
+        exit 1
+        ;;
+      *)
+        local CURRENT_TASK
+        CURRENT_TASK=$(oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+          -o jsonpath='{.status.childReferences[-1].name}' 2>/dev/null || echo "starting")
+        echo "[${ELAPSED}s] Status: ${STATUS}, Current: ${CURRENT_TASK}"
+        ;;
+    esac
+
+    sleep ${POLL_INTERVAL}
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+  done
+
+  if [ ${ELAPSED} -ge ${TIMEOUT_SECONDS} ]; then
+    echo "ERROR: Timeout waiting for Windows installation"
+    exit 1
+  fi
+
+  for attempt in 1 2 3; do
+    if oc label pvc "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" app=ocp-virt-validation --overwrite; then
+      break
+    fi
+    [ "${attempt}" -lt 3 ] && echo "WARNING: Failed to label PVC (attempt ${attempt}/3), retrying in 5s..." && sleep 5
+  done
+  if [ "$(oc get pvc "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o jsonpath='{.metadata.labels.app}')" != "ocp-virt-validation" ]; then
+    echo "ERROR: Failed to label PVC '${GOLDEN_IMAGE_NAME}' -- cleanup cannot identify tool-created resources."
+    exit 1
+  fi
+
+  # The pipeline fills the disk via a VM, so CDI never marks the DV as Succeeded
+  # (it stays PendingPopulation). Annotate the PVC to tell CDI it was populated,
+  # which causes CDI to transition the DV to Succeeded.
+  local DV_UID
+  DV_UID=$(oc get dv "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || echo "")
+  if [ -n "${DV_UID}" ]; then
+    for attempt in 1 2 3; do
+      if oc annotate pvc "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+        "cdi.kubevirt.io/storage.populatedFor=${DV_UID}" --overwrite 2>/dev/null; then
+        break
+      fi
+      [ "${attempt}" -lt 3 ] && echo "WARNING: Failed to annotate PVC (attempt ${attempt}/3), retrying in 5s..." && sleep 5 || true
+    done
+  fi
+}
+
+# NOTE: Keep autounattend.xml and post-update.ps1 in sync with
+# manifests/windows/golden-image.yaml (ConfigMap: win2k22-autounattend)
 create_autounattend_configmap() {
   echo "Creating custom autounattend ConfigMap for Windows Server 2022..."
   oc delete configmap "${AUTOUNATTEND_CM_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
@@ -189,14 +336,14 @@ data:
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <UserAccounts>
             <AdministratorPassword>
-              <Value>Heslo123</Value>
+              <Value>Administrator</Value>
               <PlainText>true</PlainText>
             </AdministratorPassword>
           </UserAccounts>
           <AutoLogon>
             <Enabled>true</Enabled>
             <Password>
-              <Value>Heslo123</Value>
+              <Value>Administrator</Value>
               <PlainText>true</PlainText>
             </Password>
             <Username>Administrator</Username>
@@ -222,277 +369,197 @@ data:
       </settings>
     </unattend>
   post-update.ps1: |
-    # Critical section - abort on any failure
-    \$ErrorActionPreference = 'Stop'
+    try {
+      \$ErrorActionPreference = 'Stop'
 
-    # Install QEMU guest agent
-    Start-Process msiexec -Wait -ArgumentList "/i E:\\guest-agent\\qemu-ga-x86_64.msi /qn /passive /norestart"
+      # Install QEMU guest agent
+      Start-Process msiexec -Wait -ArgumentList "/i E:\\guest-agent\\qemu-ga-x86_64.msi /qn /passive /norestart"
 
-    # Install and start OpenSSH server
-    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-    Set-Service -Name sshd -StartupType Automatic
-    Start-Service sshd
+      # Install and start OpenSSH server
+      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+      Set-Service -Name sshd -StartupType Automatic
+      Start-Service sshd
 
-    # Disable Windows Firewall entirely
-    Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+      # Disable Windows Firewall entirely
+      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
-    # Non-critical cleanup - continue on error
-    \$ErrorActionPreference = 'Continue'
+      \$ErrorActionPreference = 'Continue'
 
-    # Suppress network location wizard and set profile
-    New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
-    Set-NetConnectionProfile -InterfaceAlias "Ethernet" -NetworkCategory Private -ErrorAction SilentlyContinue
+      # Suppress network location wizard and set profile
+      New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
+      Set-NetConnectionProfile -InterfaceAlias "Ethernet" -NetworkCategory Private -ErrorAction SilentlyContinue
 
-    # Disable Server Manager auto-launch
-    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Value 1
+      # Disable Server Manager auto-launch
+      Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Value 1
 
-    # Cleanup for smaller image
-    \$PageFile = Get-CimInstance -ClassName Win32_PageFileSetting -Filter "Name like '%pagefile.sys'"
-    if (\$PageFile) {
-      \$PageFile | Remove-CimInstance
-      \$PageFile = New-CimInstance -ClassName Win32_PageFileSetting -Property @{ Name= "C:\\pagefile.sys" }
-      \$PageFile | Set-CimInstance -Property @{ InitialSize = 0; MaximumSize = 0 }
+      # Cleanup for smaller image (with timeouts to avoid hangs)
+      Vssadmin delete shadows /all /quiet 2>\$null
+      Remove-Item -Path \$env:Temp -Recurse -Force -ErrorAction SilentlyContinue
+      powercfg -h off 2>\$null
+
+      # DISM can hang -- run with a timeout
+      \$dismJob = Start-Job { dism.exe /online /Cleanup-Image /StartComponentCleanup }
+      if (-not (Wait-Job \$dismJob -Timeout 300)) {
+        Stop-Job \$dismJob
+        Remove-Job \$dismJob -Force
+      } else {
+        Remove-Job \$dismJob
+      }
+
+      # Rename cached unattend.xml to prevent sysprep issues
+      if (Test-Path "C:\\Windows\\Panther\\unattend.xml") {
+        Rename-Item "C:\\Windows\\Panther\\unattend.xml" "C:\\Windows\\Panther\\unattend.install.xml"
+      }
+
+      # Eject CD
+      try { (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject") } catch {}
     }
-    Vssadmin delete shadows /all /quiet
-    Remove-Item -Path \$env:Temp -Recurse -Force -ErrorAction SilentlyContinue
-    dism.exe /online /Cleanup-Image /StartComponentCleanup
-    powercfg -h off
-
-    # Rename cached unattend.xml to prevent sysprep issues
-    if (Test-Path "C:\\Windows\\Panther\\unattend.xml") {
-      mv C:\\Windows\\Panther\\unattend.xml C:\\Windows\\Panther\\unattend.install.xml
+    finally {
+      # Disable Windows Update to prevent it from blocking shutdown
+      Stop-Service wuauserv -Force -ErrorAction SilentlyContinue
+      Set-Service wuauserv -StartupType Disabled -ErrorAction SilentlyContinue
+      # Always shut down, even if errors occurred above
+      Stop-Computer -Force
     }
-
-    # Eject CD and shut down
-    (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
-    Stop-Computer -Force
 EOF
 }
 
 # --- Main Script ---
 
 echo "=== Windows Server 2022 Golden Image Setup ==="
+echo "Using golden image name: ${GOLDEN_IMAGE_NAME}"
 
-# Step 1: Check if EULA is accepted
+# BYOI path: if DataSource already exists and is Ready, nothing to do.
+DS_READY=$(oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+if [ "${DS_READY}" == "True" ]; then
+  DS_LABEL="$(oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+    -o jsonpath='{.metadata.labels.app}' 2>/dev/null || true)"
+  if [ "${DS_LABEL}" == "ocp-virt-validation" ]; then
+    echo "DataSource '${GOLDEN_IMAGE_NAME}' already exists and is Ready (previous tool run)."
+  else
+    echo "DataSource '${GOLDEN_IMAGE_NAME}' already exists and is Ready (BYOI)."
+  fi
+  echo "Skipping golden image setup — using existing image."
+  echo ""
+  echo "=== Windows Server 2022 Golden Image Ready ==="
+  echo "DataSource: ${GOLDEN_IMAGE_NAME} (namespace: ${GOLDEN_IMAGE_NAMESPACE})"
+  exit 0
+fi
+
+# Tool-managed path: EULA required to download and create the image
 if [ "${ACCEPT_WINDOWS_EULA}" != "true" ]; then
-  echo "ACCEPT_WINDOWS_EULA is not set to 'true'"
-  echo "Skipping Windows golden image setup"
-  echo "To enable Windows tests, set ACCEPT_WINDOWS_EULA=true"
+  echo "ACCEPT_WINDOWS_EULA is not set to 'true' and no existing DataSource found."
+  echo "Skipping Windows golden image setup."
+  echo ""
+  echo "To enable Windows tests, either:"
+  echo "  - Set ACCEPT_WINDOWS_EULA=true (tool will download and install Windows from Microsoft)"
+  echo "  - Apply the BYOI manifests: oc apply -f manifests/windows/golden-image.yaml"
   exit 0
 fi
 
 echo "Microsoft EULA accepted by user"
-echo "Using golden image name: ${GOLDEN_IMAGE_NAME}"
 
-# Step 2: Check if OpenShift Pipelines is installed
 echo "Checking if OpenShift Pipelines operator is installed..."
 if ! oc get crd pipelines.tekton.dev &>/dev/null; then
-  echo "ERROR: OpenShift Pipelines operator is not installed"
+  echo "WARNING: OpenShift Pipelines operator is not installed."
+  echo "Cannot create Windows golden image without OpenShift Pipelines."
+  echo "Windows tests will be skipped. All other test suites will run normally."
   echo ""
-  echo "Please install the OpenShift Pipelines operator from OperatorHub:"
+  echo "To enable Windows tests, install the OpenShift Pipelines operator from OperatorHub:"
   echo "  1. Go to OperatorHub in the OpenShift Console"
   echo "  2. Search for 'Red Hat OpenShift Pipelines'"
   echo "  3. Install the operator"
   exit 1
 fi
-
 echo "OpenShift Pipelines operator is installed"
 
-# Step 3: Ensure the golden image namespace exists
+# Tool-managed: create namespace, RBAC, run pipeline, create DataSource, cleanup on completion
+CREATED_PIPELINE_SA=false
+trap 'exit_code=$?; cleanup_pipeline_sa; cleanup_autounattend_cm; if [ $exit_code -ne 0 ]; then cleanup_namespace; fi' EXIT
+
 echo "Ensuring namespace ${GOLDEN_IMAGE_NAMESPACE} exists..."
 if ! oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
   echo "Creating namespace ${GOLDEN_IMAGE_NAMESPACE}..."
   oc create namespace "${GOLDEN_IMAGE_NAMESPACE}"
+  oc label namespace "${GOLDEN_IMAGE_NAMESPACE}" app=ocp-virt-validation --overwrite
+else
+  echo "Namespace ${GOLDEN_IMAGE_NAMESPACE} already exists"
+  NS_LABEL=$(oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" -o jsonpath='{.metadata.labels.app}' 2>/dev/null || echo "")
+  if [ "${NS_LABEL}" != "ocp-virt-validation" ]; then
+    echo "ERROR: Namespace '${GOLDEN_IMAGE_NAMESPACE}' exists but is not tool-managed (missing app=ocp-virt-validation label)."
+    echo "Cannot run automated Windows setup in a customer-owned namespace."
+    echo ""
+    echo "To resolve, either:"
+    echo "  - Wait for the BYOI DataSource to become Ready (tool will detect and reuse it)"
+    echo "  - Delete the namespace before using ACCEPT_WINDOWS_EULA=true"
+    exit 1
+  fi
 fi
 
 oc label namespace "${GOLDEN_IMAGE_NAMESPACE}" pod-security.kubernetes.io/enforce=privileged --overwrite
 
-# Step 4: Check if golden image DataSource already exists
-echo "Checking if Windows golden image already exists..."
-if oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
-  echo "Windows golden image DataSource '${GOLDEN_IMAGE_NAME}' already exists in ${GOLDEN_IMAGE_NAMESPACE}"
-  echo "Skipping image creation"
-  exit 0
-fi
-
-# Step 5: Ensure pipeline service account exists
-CREATED_PIPELINE_SA=false
-echo "Ensuring pipeline service account exists..."
-if ! oc get sa pipeline -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
-  echo "Creating pipeline service account..."
-  oc create serviceaccount pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
-  oc adm policy add-scc-to-user privileged -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
-  oc adm policy add-role-to-user edit -z pipeline -n "${GOLDEN_IMAGE_NAMESPACE}"
-  CREATED_PIPELINE_SA=true
-fi
-
-trap 'cleanup_pipeline_sa; cleanup_autounattend_cm' EXIT
-
-# Step 6: Verify storage class and detect snapshot class
-if [ -z "${STORAGE_CLASS}" ]; then
-  echo "ERROR: STORAGE_CLASS is not set"
-  exit 1
-fi
-detect_snapshot_class
-
-echo "Using storage class: ${STORAGE_CLASS}"
-echo "Using snapshot class: ${VOLUME_SNAPSHOT_CLASS}"
-echo "Using Windows ISO URL: ${WIN_IMAGE_URL}"
-echo "Using instance type: ${INSTANCE_TYPE}"
-
-# Step 7: Create custom autounattend ConfigMap
-create_autounattend_configmap
-
-# Step 8: Check if PVC already exists (skip pipeline if so)
-if oc get pvc "${SYSPREP_DV_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
-  echo "PVC '${SYSPREP_DV_NAME}' already exists - skipping pipeline"
-else
-  echo ""
-  echo "=== Running Windows Server 2022 Installation Pipeline ==="
-
-PIPELINE_RUN_NAME=$(oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF | grep -oP 'pipelinerun.tekton.dev/\K[^ ]+'
-apiVersion: tekton.dev/v1
-kind: PipelineRun
+echo "Ensuring CDI clone RBAC exists..."
+cat <<'RBAC_EOF' | oc apply -n "${GOLDEN_IMAGE_NAMESPACE}" -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  generateName: win2022-golden-
+  name: os-images.kubevirt.io:view
   labels:
     app: ocp-virt-validation
-spec:
-  timeouts:
-    pipeline: "3h"
-  pipelineRef:
-    resolver: hub
-    params:
-      - name: catalog
-        value: redhat-pipelines
-      - name: type
-        value: artifact
-      - name: kind
-        value: pipeline
-      - name: name
-        value: windows-efi-installer
-      - name: version
-        value: "${PIPELINE_VERSION}"
-  params:
-    - name: winImageDownloadURL
-      value: "${WIN_IMAGE_URL}"
-    - name: acceptEula
-      value: "${ACCEPT_WINDOWS_EULA}"
-    - name: baseDvName
-      value: "${SYSPREP_DV_NAME}"
-    - name: baseDvNamespace
-      value: "${GOLDEN_IMAGE_NAMESPACE}"
-    - name: instanceTypeName
-      value: "${INSTANCE_TYPE}"
-    - name: instanceTypeKind
-      value: "VirtualMachineClusterInstancetype"
-    - name: preferenceName
-      value: "windows.2k22"
-    - name: preferenceKind
-      value: "VirtualMachineClusterPreference"
-    - name: autounattendConfigMapName
-      value: "${AUTOUNATTEND_CM_NAME}"
-  taskRunSpecs:
-    - pipelineTaskName: modify-windows-iso-file
-      podTemplate:
-        securityContext:
-          fsGroup: 107
-          runAsUser: 107
-EOF
-)
+rules:
+- apiGroups: [""]
+  resources: [persistentvolumeclaims, persistentvolumeclaims/status]
+  verbs: [get, list, watch]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshots, volumesnapshots/status]
+  verbs: [get, list, watch]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datavolumes]
+  verbs: [get, list, watch]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datavolumes/source]
+  verbs: [create]
+- apiGroups: [cdi.kubevirt.io]
+  resources: [datasources]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: os-images.kubevirt.io:view
+  labels:
+    app: ocp-virt-validation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: os-images.kubevirt.io:view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts
+RBAC_EOF
 
-if [ -z "${PIPELINE_RUN_NAME}" ]; then
-  echo "ERROR: Failed to create PipelineRun or parse its name"
-  exit 1
+if oc get pvc "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
+  echo "Found leftover PVC from a previous run — deleting and rebuilding."
+  oc delete pvc "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" --wait=true
 fi
+run_pipeline
 
-echo "Created PipelineRun: ${PIPELINE_RUN_NAME}"
-
-# Step 9: Wait for pipeline to complete
-echo "Waiting for Windows installation to complete (this may take up to 3 hours)..."
-
-TIMEOUT_SECONDS=10800
-POLL_INTERVAL=60
-ELAPSED=0
-
-while [ ${ELAPSED} -lt ${TIMEOUT_SECONDS} ]; do
-  STATUS=$(oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-    -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || echo "Unknown")
-
-  case "${STATUS}" in
-    "Succeeded")
-      echo "Pipeline completed successfully!"
-      break
-      ;;
-    "Failed"|"PipelineRunTimeout"|"TaskRunCancelled"|"CouldntGetPipeline")
-      echo "ERROR: Pipeline failed with status: ${STATUS}"
-      if [ "${STATUS}" == "CouldntGetPipeline" ]; then
-        echo "Failed to fetch pipeline from artifacthub."
-        echo "For disconnected environments, manually install the pipeline first:"
-        echo "  https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer"
-      fi
-      oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o yaml | tail -50
-      exit 1
-      ;;
-    *)
-      CURRENT_TASK=$(oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-        -o jsonpath='{.status.childReferences[-1].name}' 2>/dev/null || echo "starting")
-      echo "[${ELAPSED}s] Status: ${STATUS}, Current: ${CURRENT_TASK}"
-      ;;
-  esac
-
-  sleep ${POLL_INTERVAL}
-  ELAPSED=$((ELAPSED + POLL_INTERVAL))
-done
-
-if [ ${ELAPSED} -ge ${TIMEOUT_SECONDS} ]; then
-  echo "ERROR: Timeout waiting for Windows installation"
-  exit 1
-fi
-
-fi  # end of pipeline skip check
-
-# Step 10: Create snapshot from the ready PVC
+# Create DataSource pointing to the PVC
 echo ""
-echo "=== Creating Golden Image Snapshot ==="
+echo "=== Configuring DataSource ==="
 
-oc delete volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: ${SNAPSHOT_NAME}
-  labels:
-    app: ocp-virt-validation
-spec:
-  volumeSnapshotClassName: ${VOLUME_SNAPSHOT_CLASS}
-  source:
-    persistentVolumeClaimName: ${SYSPREP_DV_NAME}
-EOF
-
-echo "Waiting for snapshot to be ready..."
-SNAP_TIMEOUT=300
-SNAP_ELAPSED=0
-while [ ${SNAP_ELAPSED} -lt ${SNAP_TIMEOUT} ]; do
-  READY=$(oc get volumesnapshot "${SNAPSHOT_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
-    -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
-  if [ "${READY}" == "true" ]; then
-    echo "VolumeSnapshot '${SNAPSHOT_NAME}' is ready"
-    break
-  fi
-  sleep 5
-  SNAP_ELAPSED=$((SNAP_ELAPSED + 5))
-done
-
-if [ "${READY}" != "true" ]; then
-  echo "ERROR: Timeout waiting for snapshot"
-  exit 1
-fi
-
-# Step 11: Create the final DataSource
-echo "Creating DataSource '${GOLDEN_IMAGE_NAME}' from snapshot..."
-oc delete datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
-oc create -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<EOF
+echo "Creating DataSource '${GOLDEN_IMAGE_NAME}'..."
+DS_APPLIED=false
+for attempt in 1 2 3; do
+  if oc apply -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<DSEOF
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataSource
 metadata:
@@ -501,12 +568,41 @@ metadata:
     app: ocp-virt-validation
 spec:
   source:
-    snapshot:
-      name: ${SNAPSHOT_NAME}
+    pvc:
+      name: ${GOLDEN_IMAGE_NAME}
       namespace: ${GOLDEN_IMAGE_NAMESPACE}
-EOF
+DSEOF
+  then
+    DS_APPLIED=true
+    break
+  fi
+  [ "${attempt}" -lt 3 ] && echo "WARNING: Failed to apply DataSource (attempt ${attempt}/3), retrying in 10s..." && sleep 10
+done
+if [ "${DS_APPLIED}" != "true" ]; then
+  echo "ERROR: Failed to create DataSource after 3 attempts"
+  exit 1
+fi
 
-# Cleanup
+echo "Waiting for DataSource to become Ready..."
+for i in $(seq 1 60); do
+  DS_READY=$(oc get datasource "${GOLDEN_IMAGE_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+  if [ "${DS_READY}" == "True" ]; then
+    echo "DataSource '${GOLDEN_IMAGE_NAME}' is Ready"
+    break
+  fi
+  echo "  Not ready yet (attempt ${i}/60), waiting 10s..."
+  sleep 10
+done
+
+if [ "${DS_READY}" != "True" ]; then
+  echo "ERROR: DataSource '${GOLDEN_IMAGE_NAME}' is not Ready after 10 minutes"
+  echo "The PVC exists but the DataSource failed to reconcile."
+  echo "Check with: oc get datasource ${GOLDEN_IMAGE_NAME} -n ${GOLDEN_IMAGE_NAMESPACE} -o yaml"
+  exit 1
+fi
+
+# Cleanup pipeline resources (SA, autounattend CM)
 trap - EXIT
 cleanup_pipeline_sa
 cleanup_autounattend_cm
@@ -514,7 +610,7 @@ cleanup_autounattend_cm
 echo ""
 echo "=== Windows Server 2022 Golden Image Setup Complete ==="
 echo "DataSource: ${GOLDEN_IMAGE_NAME} (namespace: ${GOLDEN_IMAGE_NAMESPACE})"
-echo "Snapshot:   ${SNAPSHOT_NAME}"
+echo "PVC:        ${GOLDEN_IMAGE_NAME}"
 echo ""
-echo "Login: Administrator / Heslo123"
+echo "Login: Administrator / Administrator"
 echo "SSH:   Enabled on port 22"


### PR DESCRIPTION
## Summary

Enable Windows testing in the self-validation conformance suite,  A ready-to-use manifest ([`manifests/windows/golden-image.yaml`](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/manifests/windows/golden-image.yaml)) is provided that creates a Windows Server 2022 golden image from scratch via Tekton pipeline — including namespace, RBAC, sysprep (SSH, guest agent, vTPM, `Administrator/Administrator`), and a PipelineRun,  Single `oc apply`, full automation.

**Two paths to get the DataSource ready:**
- **Customer-managed** — user applies the manifest, pipeline creates the image. Once DataSource is Ready, the tool detects it and runs Windows tests. Nothing is deleted afterward.
- **Tool-managed** (`ACCEPT_WINDOWS_EULA=true`) — the tool handles image creation automatically (default Microsoft eval ISO, or user-provided URL), runs tests, then cleans up.

Windows tests are discovered from Tier-2 ([`openshift-virtualization-tests`](https://github.com/RedHatQE/openshift-virtualization-tests)) using the `conformance` and `windows` pytest markers, and run automatically once the DataSource is Ready.

**Documentation:** [`README.md`](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/README.md#windows-testing-optional) | [`disconnected/README.md`](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/disconnected/README.md)

## Flow

```mermaid
flowchart TD
    A["DataSource 'win2k22' exists and Ready?"] -->|Yes| B["Option 1: Customer-managed"]
    A -->|No| C["ACCEPT_WINDOWS_EULA=true?"]
    B --> B1["Run tests, delete nothing"]
    C -->|No| D["Skip Windows tests"]
    C -->|Yes| E["WIN_IMAGE_DOWNLOAD_URL set?"]
    E -->|No| F["Option 2: Default MS ISO"]
    E -->|Yes| G["Option 3: Custom ISO URL"]
    F --> H["Pipeline installs Windows"]
    G --> H
    H --> I["Run tests, delete everything"]
```

## Options

| # | Option | User Does | Tool Does | Cleanup |
|---|--------|-----------|-----------|---------|
| 1 | **Customer-managed** | Applies [manifests/windows/golden-image.yaml](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/manifests/windows/golden-image.yaml) (Tekton pipeline creates image) | Detects DataSource is Ready, runs tests. | **Nothing** — user owns all resources. |
| 2 | **Default ISO** (tool-managed) | Sets ACCEPT\_WINDOWS\_EULA=true. | Downloads MS evaluation ISO, runs pipeline, creates all resources, runs tests. | **Deletes entire validation-os-images namespace.** |
| 3 | **Custom ISO** (tool-managed) | Sets ACCEPT\_WINDOWS\_EULA=true + WIN\_IMAGE\_DOWNLOAD\_URL=\<url\>. | Uses provided ISO URL, runs pipeline, creates all resources, runs tests. | **Deletes entire validation-os-images namespace.** |

## Customer-Managed Manifest (`golden-image.yaml`)

A reference manifest [`manifests/windows/golden-image.yaml`](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/manifests/windows/golden-image.yaml) is provided for the customer to use directly (`oc apply -f`) or as a reference. This will also be exposed in the UI. Two methods:

| Method | When to use | Source |
|--------|-------------|--------|
| **1: Tekton pipeline** (default) | No existing image, build from scratch | ISO URL (default Microsoft eval or custom) |
| **2: [DataVolume import](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/manifests/windows/golden-image.yaml#L355-L400)** (commented out) | Already have a prepared image | HTTP / registry / upload |

### What it creates:

| Resource | Purpose |
|----------|---------|
| Namespace validation-os-images | Isolated namespace for golden images |
| Role + RoleBinding | CDI DataVolume RBAC |
| ServiceAccount pipeline | For Tekton pipeline execution |
| ClusterRoleBinding (privileged SCC) | Pipeline needs privileged access |
| ConfigMap win2k22-autounattend | Sysprep: autounattend.xml + post-update.ps1 |
| PipelineRun win2022-install | Tekton pipeline (windows-efi-installer) |
| DataSource win2k22 | Points to the resulting PVC |

### Windows image configuration (via sysprep in ConfigMap):

- **autounattend.xml**: EFI partition layout (vTPM), Administrator/Administrator, auto-logon, triggers post-update.ps1
- **post-update.ps1**: Installs QEMU guest agent, enables OpenSSH (port 22), disables firewall, shuts down VM

## Cleanup

Binary, no edge cases:

- `ACCEPT_WINDOWS_EULA` set (Options 2 & 3) → tool created everything → delete entire namespace
- `ACCEPT_WINDOWS_EULA` not set (Option 1) → customer-managed → delete nothing

Post-pipeline steps (PVC labeling, DataSource creation) retry on transient failures. If a leftover PVC is found from a previous crash, it's deleted and the pipeline reruns.

## Files Changed

| File | Change |
|------|--------|
| [manifests/windows/golden-image.yaml](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/manifests/windows/golden-image.yaml) | **New** — unified manifest with Tekton pipeline + DataVolume import options (includes sysprep ConfigMap) |
| [scripts/windows/setup-golden-image.sh](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/scripts/windows/setup-golden-image.sh) | Refactored tool-managed path (EULA flow) |
| [scripts/entrypoint.sh](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/scripts/entrypoint.sh) | Integration with golden image setup + BYOI detection |
| [scripts/tier2/test-tier2.sh](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/scripts/tier2/test-tier2.sh) | Windows test markers + login config when golden image is available |
| [README.md](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/README.md) | Updated documentation with Windows support instructions |
| [disconnected/README.md](https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/feat/win2k22-datasource-simplify/disconnected/README.md) | Disconnected environment notes |

##  additional things were Fixed also in this PR beside the windows support flow so everything work e2e (self validtion) 

| File | Fix | Reason |
|------|-----|--------|
| `scripts/tier2/test-tier2.sh` | Removed `-W "ignore::pytest.PytestRemovedIn9Warning"` from both pytest invocations (dry-run and real run) | The class `pytest.PytestRemovedIn9Warning` no longer exists in the pytest version used by `openshift-virtualization-tests` (Python 3.14). Keeping the flag causes an `AttributeError` that breaks the entire test run. |
| `scripts/tier2/test-tier2.sh` | Appended `\|\| true` to `oc get datasource ... 2>/dev/null` commands (`DS_READY` and `DS_LABEL` assignments) | Caused the `e2e-aws` CI failure. `set -e` + `oc get datasource` returning non-zero (no Windows image in CI) kills the tier2 script silently — `2>/dev/null` suppresses stderr but not the exit code. |
| `scripts/tier2/test-tier2.sh` | Added `--tc=storage_class_a:${STORAGE_CLASS}` and `--tc=storage_class_b:${STORAGE_CLASS}` to both pytest invocations (dry-run and real run) | Preparation for storage migration tests that are planned to be added to self-validation. These tests require `storage_class_a`/`storage_class_b` to be configured — without them the fixtures fail with missing config. |
| `scripts/windows/setup-golden-image.sh` / `scripts/entrypoint.sh` | Gracefully handle missing OpenShift Pipelines operator when `ACCEPT_WINDOWS_EULA=true` — log warning and skip Windows tests instead of crashing the entire suite | Missing Pipelines prerequisite caused `exit 1` in `setup-golden-image.sh`, which under `set -e` killed `entrypoint.sh` — no tests from any suite (compute, network, storage, ssp, tier2) would run. Fixes [CNV-92678](https://redhat.atlassian.net/browse/CNV-92678). |


## Test Plan

- [x] Applied `golden-image.yaml` on cluster — all resources created successfully
- [x] PipelineRun completes (~28 min) → PVC populated → DataSource Ready
- [x] Self-validation tool detects DataSource Ready → runs Windows hotplug tests
- [x] 3/3 hotplug tests passed (virtio-bus, scsi-bus, serial persist)
- [x] BYOI detection: DataSource Ready → tests run → no cleanup
- [x] EULA flow: tool runs pipeline internally, cleans up namespace after

### Edge Case Verification Matrix

Verified with `DRY_RUN=true` and full pipeline E2E runs on a live cluster:

| # | Scenario | Expected | Status |
|---|----------|----------|--------|
| 1a | Clean state, no EULA | Skip Windows, markers: `conformance and not windows` | :white_check_mark: |
| 1b | BYOI DataSource Ready, no EULA | Detect BYOI, include Windows tests, NS preserved | :white_check_mark: |
| 1c | BYOI DataSource Ready + EULA=true | BYOI takes priority, pipeline never runs, NS preserved | :white_check_mark: |
| 2a | Clean state, EULA=true, Pipelines installed | NS created with tool label, pipeline runs, NS deleted on cleanup | :white_check_mark: |
| 2b | EULA=true, Pipelines NOT installed | Exit 1 → entrypoint unsets EULA → skip Windows, no resource leak | :mag: code review |
| 2c | EULA=true, NS exists without tool label | Fail fast: "customer-owned namespace" error | :white_check_mark: |
| 2d | EULA=true, stale tool-labeled NS | Reuse NS, pipeline runs, NS deleted on cleanup | :white_check_mark: |
| 3a | Stale tool DS + tool NS, no EULA | Tier2 deletes entire namespace | :white_check_mark: |
| 3b | Stale tool DS + user NS, no EULA | Tier2 deletes only labeled resources, NS preserved | :white_check_mark: |
| 4a | Pipeline failure mid-run | EXIT trap cleans up SA, CM, tool NS | :mag: code review |
| 4b | SIGTERM during setup | Trap fires immediately, NS deleted (was deferred before fix) | :white_check_mark: |
| 4c | Setup exits 1 (any reason) | Entrypoint calls cleanup BEFORE unsetting EULA, NS cleaned | :white_check_mark: (via 2c) |
| 5a | User NS + no EULA | Zero modifications to user resources | :white_check_mark: |
| 5b | User NS + EULA=true | Fail fast, no user resources modified | :white_check_mark: (via 2c) |
| 5c | Tool-labeled DS in user NS | Tier2 stale cleanup: labeled resources only, NS preserved | :white_check_mark: (via 3b) |
| 5d | User-created pipeline SA | Covered by NS ownership model | :white_check_mark: (via 2a, 2c) |
| 5e | User NS with RBAC, SA, PVC, CM + stale tool DS | Stale cleanup: only tool-labeled DS/PVC deleted, all user resources preserved | :white_check_mark: |





| # | What the user has | EULA | What happens | User resources safe? |
|---|-------------------|------|-------------|---------------------|
| A | User-owned DataSource (Ready) | no | BYOI detected → Windows tests included | :white_check_mark: All preserved |
| B | User-owned DataSource (Ready) | yes | BYOI takes priority over pipeline → Windows tests included | :white_check_mark: All preserved |
| C | No DataSource at all | no | Windows tests skipped | :white_check_mark: All preserved |
| D | No DataSource at all | yes | Fail fast: "customer-owned namespace" → Windows skipped | :white_check_mark: All preserved |
| E | Stale tool DS (Ready) | yes | Treated as BYOI (Ready) → Windows tests included | :white_check_mark: All preserved |
| F | Stale tool DS (broken, not Ready) | no | **Gap found**: previously ignored. Now fixed — stale DS cleaned up | :white_check_mark: Only stale DS deleted |
| G | Stale tool DS (broken, not Ready) | yes | Fail fast: "customer-owned namespace" → Windows skipped | :white_check_mark: All preserved |

