### PR TITLE
ci: propagate ACCEPT_WINDOWS_EULA and copy result archives to ARTIFACT_DIR

### DIFF
--- a/ci/download-results.sh
+++ b/ci/download-results.sh
@@ -48,7 +48,7 @@ if [ ! -s "${SUMMARY_LOG}" ]; then
   exit 1
 fi
 
-# Copy JUnit files to ARTIFACT_DIR if the variable is set (for Prow CI)
+# Copy JUnit files and result archives to ARTIFACT_DIR if the variable is set (for Prow CI)
 if [ -n "${ARTIFACT_DIR:-}" ]; then
   echo "=== Copying JUnit files to ${ARTIFACT_DIR} ==="
 
@@ -71,6 +71,19 @@ if [ -n "${ARTIFACT_DIR:-}" ]; then
     echo "Total JUnit files copied: ${JUNIT_COUNT}"
   else
     echo "Warning: No JUnit files found in ${RESULTS_DIR}"
+  fi
+
+  echo "=== Copying result archives to ${ARTIFACT_DIR} ==="
+  TARBALL_COUNT=0
+  for tarball in "${RESULTS_DIR}"/test-results-*.tar.gz; do
+    if [ -f "${tarball}" ]; then
+      cp "${tarball}" "${ARTIFACT_DIR}/"
+      TARBALL_COUNT=$((TARBALL_COUNT + 1))
+      echo "  Copied: $(basename ${tarball})"
+    fi
+  done
+  if [ "${TARBALL_COUNT}" -eq 0 ]; then
+    echo "Warning: No test-results tar.gz files found in ${RESULTS_DIR}"
   fi
   echo ""
 fi

--- a/ci/run-ci-validation-disconnected.sh
+++ b/ci/run-ci-validation-disconnected.sh
@@ -10,6 +10,7 @@ KUBEVIRT_RELEASE="${KUBEVIRT_RELEASE:-}"
 PULL_SECRET="${PULL_SECRET:-}"
 DRY_RUN="${DRY_RUN:-true}"
 OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT:-10m}"
+ACCEPT_WINDOWS_EULA="${ACCEPT_WINDOWS_EULA:-false}"
 
 cleanup() {
   rm -f "${CLUSTER_PULL_SECRET:-}" 2>/dev/null || true
@@ -95,6 +96,7 @@ echo "=== Running disconnected validation checkup ==="
 OCP_VIRT_VALIDATION_IMAGE="${OCP_VIRT_VALIDATION_IMAGE:-}" \
 DRY_RUN="${DRY_RUN}" \
 OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT}" \
+ACCEPT_WINDOWS_EULA="${ACCEPT_WINDOWS_EULA}" \
   "${SCRIPT_DIR}/run-ci-validation.sh"
 
 echo "=== Disconnected validation checkup completed successfully ==="

--- a/ci/run-ci-validation.sh
+++ b/ci/run-ci-validation.sh
@@ -20,10 +20,12 @@ fi
 # Set environment variables with defaults
 DRY_RUN="${DRY_RUN:-true}"
 OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT:-10m}"
+ACCEPT_WINDOWS_EULA="${ACCEPT_WINDOWS_EULA:-false}"
 
 echo "=== Generating and applying validation checkup manifests ==="
 DRY_RUN="${DRY_RUN}" \
 OCP_VIRT_VALIDATION_IMAGE="${OCP_VIRT_VALIDATION_IMAGE}" \
+ACCEPT_WINDOWS_EULA="${ACCEPT_WINDOWS_EULA}" \
   ${REPO_ROOT}/manifests/run/generate.sh | oc apply -f -
 
 echo "=== Waiting for job to complete (timeout: ${OCP_VIRT_VALIDATION_TIMEOUT}) ==="


### PR DESCRIPTION
## Summary
- Propagate `ACCEPT_WINDOWS_EULA` (default `false`) through `run-ci-validation.sh` and `run-ci-validation-disconnected.sh` so it reaches `generate.sh` and the validation Job.
- Copy `test-results-*.tar.gz` archives to `ARTIFACT_DIR` alongside the renamed JUnit files, so Prow can surface the full test results.

## What this PR does / why we need it
The CI scripts were not forwarding `ACCEPT_WINDOWS_EULA` to `generate.sh`, so callers had to rely on the default value set in `generate.sh`. This change lets CI jobs control it explicitly via environment variable.

Additionally, only JUnit XML files were being copied to `ARTIFACT_DIR` for Prow. The result tar.gz archives (containing logs, detailed results, etc.) were left behind, making it harder to analyze failures in Prow. Now they are copied too.

🤖 Generated with [Claude Code](https://claude.ai/code)