### PR TITLE
CNV-92581: fix: replace removed PytestRemovedIn9Warning with PytestRemovedIn10Warning

### DIFF
--- a/scripts/tier2/test-tier2.sh
+++ b/scripts/tier2/test-tier2.sh
@@ -219,7 +219,7 @@ if [ "${DRY_RUN}" == "true" ]; then
   # testcase elements -- aligned with how Ginkgo's --ginkgo.dry-run works.
   (set +e; .venv/bin/pytest \
     -m "${MARKERS}" \
-    -W "ignore::pytest.PytestRemovedIn9Warning" \
+    -W "ignore::pytest.PytestRemovedIn10Warning" \
     --skip-artifactory-check \
     --latest-rhel \
     --tc=hco_subscription:${SUBSCRIPTION_NAME} \
@@ -297,7 +297,7 @@ print(f'Generated JUnit XML with {total_tests} test(s) ({len(test_ids)} collecte
 else
   (set +e; .venv/bin/pytest \
     -m "${MARKERS}" \
-    -W "ignore::pytest.PytestRemovedIn9Warning" \
+    -W "ignore::pytest.PytestRemovedIn10Warning" \
     --skip-artifactory-check \
     --latest-rhel \
     --tc=hco_subscription:${SUBSCRIPTION_NAME} \


### PR DESCRIPTION
The pytest warning filter -W `"ignore::pytest.PytestRemovedIn9Warning"` causes a fatal `AttributeError` on `pytest >= 9.1.0`, which now strictly validates -W filter classes. `PytestRemovedIn9Warning` was removed in pytest 9.0.0; the correct class for the current 9.x series is PytestRemovedIn10Warning.

Resolves: https://redhat.atlassian.net/browse/CNV-92581