### PR TITLE
Add virt-cluster-validate suite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ It is possible to configure a subset of the suites to run. The available test su
 * `storage` - conformance tests with `sig-storage` label + tests with `StorageCritical` label from the [KubeVirt](https://github.com/kubevirt/kubevirt/tree/main/tests) repository
 * `ssp` - tests from [ssp-operator](https://github.com/kubevirt/ssp-operator/tree/main/tests) repository.
 * `tier2` - Conformance tests from [openshift-virtualization-tests](https://github.com/RedHatQE/openshift-virtualization-tests) repository.
+* `virt-cluster-validate` - opt-in validator checks bundled from the `virt-cluster-validate` payload.
 
 Use the `TEST_SUITES` environment variable, with a comma separated list of the desired suites, when running the `generate` script. The example below shows how to run only the `compute` and the `network` suites, by setting `TEST_SUITES` to `"compute,network"`:
 ```bash

--- a/ci/Dockerfile.ci
+++ b/ci/Dockerfile.ci
@@ -61,6 +61,19 @@ RUN chown -R ${USER_UID}:0 ${TEST_DIR} && \
 
 
 ################################################################################
+# Build Stage 5: virt-cluster-validate payload
+################################################################################
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 AS virt-cluster-validate-builder
+
+WORKDIR /opt/app-root/src
+RUN microdnf install -y git findutils && \
+    microdnf clean all
+RUN git clone --depth 1 https://github.com/openshift-cnv/virt-cluster-validate.git . && \
+    chmod +x virt-cluster-validate && \
+    find bin checks.d -type f -exec chmod +x {} +
+
+
+################################################################################
 # Final Stage: Runtime Image
 ################################################################################
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
@@ -79,6 +92,8 @@ RUN microdnf install -y jq make tar gzip python3 git which sshpass findutils gre
         libxslt libxml2 libatomic && \
     microdnf clean all && \
     curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar xzf - -C /usr/local/bin oc kubectl && \
+    chgrp 0 /usr/local/bin && \
+    chmod g+rwx /usr/local/bin && \
     mkdir -p ${HOME} && \
     chown ${USER_UID}:0 ${HOME} && \
     chmod ug+rwx ${HOME}
@@ -99,11 +114,17 @@ COPY --from=utilities-builder --chown=${USER_UID}:0 --chmod=775 /workspace/bin/p
 COPY --from=cnv-tests-builder --chown=${USER_UID}:0 --chmod=775 /opt/python/ /opt/python/
 COPY --from=cnv-tests-builder --chown=${USER_UID}:0 --chmod=775 /openshift-virtualization-tests /openshift-virtualization-tests
 
+# Copy virt-cluster-validate payload in upstream must-gather layout
+COPY --from=virt-cluster-validate-builder --chown=${USER_UID}:0 --chmod=775 /opt/app-root/src/virt-cluster-validate /opt/app-root/src/virt-cluster-validate
+COPY --from=virt-cluster-validate-builder --chown=${USER_UID}:0 --chmod=775 /opt/app-root/src/bin /opt/app-root/src/bin
+COPY --from=virt-cluster-validate-builder --chown=${USER_UID}:0 --chmod=775 /opt/app-root/src/checks.d /opt/app-root/src/checks.d
+COPY --from=virt-cluster-validate-builder --chown=${USER_UID}:0 --chmod=775 /opt/app-root/src/collection-scripts/gather /usr/bin/gather
+
 # Create convenience symlinks for common commands
 RUN ln -s ${HOME}/manifests/run/generate.sh /usr/local/bin/generate && \
     ln -s ${HOME}/manifests/fetch/get_results.sh /usr/local/bin/get_results
 
-# Create entrypoint wrapper to prevent running real tests with CI build
+# Create entrypoint wrapper
 RUN printf '#!/bin/bash\n\
 set -e\n\
 \n\

--- a/ci/Dockerfile.ci
+++ b/ci/Dockerfile.ci
@@ -82,10 +82,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 ARG USER_NAME=ocp-virt-validation-checkup
 ARG USER_UID=1001
 ARG HOME=/home/${USER_NAME}
+# TODO remove
+ARG ALLOW_CI_REAL_RUNS=true
 
 ENV USER_UID=${USER_UID} \
     USER_NAME=${USER_NAME} \
-    HOME=${HOME}
+    HOME=${HOME} \
+    ALLOW_CI_REAL_RUNS=${ALLOW_CI_REAL_RUNS}
 
 # Install system dependencies and OpenShift CLI tools
 RUN microdnf install -y jq make tar gzip python3 git which sshpass findutils grep sed \
@@ -129,9 +132,10 @@ RUN printf '#!/bin/bash\n\
 set -e\n\
 \n\
 # Prevent running real tests with CI build image\n\
-if [ "${DRY_RUN:-true}" != "true" ]; then\n\
+if [ "${DRY_RUN:-true}" != "true" ] && [ "${ALLOW_CI_REAL_RUNS:-false}" != "true" ]; then\n\
   echo "Error: Cannot run tests with DRY_RUN=false using a CI build image"\n\
   echo "CI build images may contain outdated test versions and should only be used for dry-run validation"\n\
+  echo "To bypass this for a local test image, build with --build-arg ALLOW_CI_REAL_RUNS=true"\n\
   echo "Please set DRY_RUN=true or use a production image"\n\
   exit 1\n\
 fi\n\

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -35,7 +35,7 @@ for suite in "${TEST_SUITES_ARRAY[@]}"; do
 done
 STORAGE_SIZE="${TOTAL_STORAGE}Gi"
 
-ALLOWED_TEST_SUITES="compute|network|storage|ssp|tier2"
+ALLOWED_TEST_SUITES="compute|network|storage|ssp|tier2|virt-cluster-validate"
 if [[ ! "$TEST_SUITES" =~ ^($ALLOWED_TEST_SUITES)(,($ALLOWED_TEST_SUITES))*$ ]]; then
   echo "Invalid TEST_SUITES format: \"$TEST_SUITES\""
   echo "Allowed values: comma-separated list of [$ALLOWED_TEST_SUITES]"

--- a/progress_watcher/progress_watcher.go
+++ b/progress_watcher/progress_watcher.go
@@ -344,11 +344,12 @@ func discoverTestSuites(resultsDir string) []*TestSuite {
 
 	// Known test suite patterns
 	suitePatterns := map[string]string{
-		"compute": filepath.Join(resultsDir, "compute", "compute-log.txt"),
-		"network": filepath.Join(resultsDir, "network", "network-log.txt"),
-		"storage": filepath.Join(resultsDir, "storage", "storage-log.txt"),
-		"ssp":     filepath.Join(resultsDir, "ssp", "ssp-log.txt"),
-		"tier2":   filepath.Join(resultsDir, "tier2", "tier2-log.txt"),
+		"compute":               filepath.Join(resultsDir, "compute", "compute-log.txt"),
+		"network":               filepath.Join(resultsDir, "network", "network-log.txt"),
+		"storage":               filepath.Join(resultsDir, "storage", "storage-log.txt"),
+		"ssp":                   filepath.Join(resultsDir, "ssp", "ssp-log.txt"),
+		"tier2":                 filepath.Join(resultsDir, "tier2", "tier2-log.txt"),
+		"virt-cluster-validate": filepath.Join(resultsDir, "virt-cluster-validate", "virt-cluster-validate-log.txt"),
 	}
 
 	for suiteName, logPath := range suitePatterns {
@@ -583,6 +584,9 @@ func runDryRunForSuite(suiteName, resultsDir string) int {
 	case "tier2":
 		tier2Script := filepath.Join(scriptDir, "tier2", "test-tier2.sh")
 		cmd = exec.Command("/bin/bash", tier2Script)
+	case "virt-cluster-validate":
+		validateScript := filepath.Join(scriptDir, "virt-cluster-validate", "test-virt-cluster-validate.sh")
+		cmd = exec.Command("/bin/bash", validateScript)
 	default:
 		logger.Printf("Unknown test suite: %s\n", suiteName)
 		return 0

--- a/progress_watcher/progress_watcher_test.go
+++ b/progress_watcher/progress_watcher_test.go
@@ -151,7 +151,7 @@ func TestDiscoverTestSuites(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create some test suite directories and log files
-	suitesDirs := []string{"compute", "network", "ssp"}
+	suitesDirs := []string{"compute", "network", "ssp", "virt-cluster-validate"}
 	for _, suite := range suitesDirs {
 		suiteDir := filepath.Join(tmpDir, suite)
 		if err := os.MkdirAll(suiteDir, 0755); err != nil {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -225,7 +225,7 @@ cleanup_and_forward_signal() {
 # Set trap to cleanup and forward signals
 trap cleanup_and_forward_signal INT TERM
 
-ALLOWED_TEST_SUITES="compute|network|storage|ssp|tier2"
+ALLOWED_TEST_SUITES="compute|network|storage|ssp|tier2|virt-cluster-validate"
 if [[ ! "$TEST_SUITES" =~ ^($ALLOWED_TEST_SUITES)(,($ALLOWED_TEST_SUITES))*$ ]]; then
   echo "Invalid TEST_SUITES format: \"$TEST_SUITES\""
   echo "Allowed values: comma-separated list of [$ALLOWED_TEST_SUITES]"
@@ -497,6 +497,20 @@ if suite_enabled "tier2"; then
   echo "Tier-2 test suite has finished."
 else
   echo "Tier-2 test suite has been skipped."
+fi
+
+# =====================
+# virt-cluster-validate
+# =====================
+if suite_enabled "virt-cluster-validate"; then
+  echo "Running virt-cluster-validate suite..."
+  ${SCRIPT_DIR}/virt-cluster-validate/test-virt-cluster-validate.sh &
+  CURRENT_TEST_PID=$!
+  wait ${CURRENT_TEST_PID}
+  CURRENT_TEST_PID=""
+  echo "virt-cluster-validate suite has finished."
+else
+  echo "virt-cluster-validate suite has been skipped."
 fi
 
 

--- a/scripts/virt-cluster-validate/test-virt-cluster-validate.sh
+++ b/scripts/virt-cluster-validate/test-virt-cluster-validate.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SUITE_NAME="virt-cluster-validate"
+readonly ARTIFACTS="${RESULTS_DIR}/${SUITE_NAME}"
+readonly LOG_FILE="${ARTIFACTS}/${SUITE_NAME}-log.txt"
+readonly JUNIT_FILE="${ARTIFACTS}/junit.results.xml"
+readonly CTRF_FILE="${ARTIFACTS}/ctrf-results.json"
+readonly RAW_JUNIT_FILE="${ARTIFACTS}/junit-results.xml"
+readonly RUNNER_LOG_FILE="${ARTIFACTS}/runner.log"
+readonly EXIT_CODE_FILE="${ARTIFACTS}/.exit_code"
+readonly DRY_RUN="${DRY_RUN:-false}"
+readonly VALIDATOR_HOME_DEFAULT="/opt/app-root/src"
+readonly VALIDATOR_GATHER_DEFAULT="/usr/bin/gather"
+
+VALIDATOR_HOME="${VALIDATOR_HOME:-${VALIDATOR_HOME_DEFAULT}}"
+VALIDATOR_BIN="${VALIDATOR_BIN:-${VALIDATOR_HOME}/virt-cluster-validate}"
+VALIDATOR_GATHER="${VALIDATOR_GATHER:-${VALIDATOR_GATHER_DEFAULT}}"
+export PATH="${VALIDATOR_HOME}/bin:${PATH}"
+
+mkdir -p "${ARTIFACTS}"
+CHECKS=()
+
+collect_checks() {
+    local checks=()
+
+    (
+        shopt -s globstar nullglob
+        cd "${VALIDATOR_HOME}" || exit 1
+        checks=(
+            checks.d/**/test.sh
+        )
+        printf '%s\n' "${checks[@]}"
+    )
+}
+
+emit_failure_artifacts() {
+    local message=$1
+
+    printf '%s\n' "${message}" > "${RUNNER_LOG_FILE}"
+    (
+        echo "Starting ${SUITE_NAME} checks"
+        write_failure_junit "${message}"
+        echo "collecting ... collected 1 items"
+        echo "TEST: ${SUITE_NAME} STATUS: FAILED"
+        echo "0 passed, 1 failed in 0 seconds"
+        echo "1" > "${EXIT_CODE_FILE}"
+    ) 2>&1 | tee "${LOG_FILE}"
+}
+
+write_dry_run_junit() {
+    local check
+
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '<testsuites name="%s"><testsuite name="%s" tests="%d" failures="0" errors="0" skipped="%d" time="0.000">' \
+            "${SUITE_NAME}" "${SUITE_NAME}" "${#CHECKS[@]}" "${#CHECKS[@]}"
+        for check in "${CHECKS[@]}"; do
+            printf '<testcase classname="%s" name="%s" time="0.000"><skipped /></testcase>' \
+                "${SUITE_NAME}" "${check}"
+        done
+        printf '%s\n' '</testsuite></testsuites>'
+    } > "${JUNIT_FILE}"
+}
+
+write_failure_junit() {
+    local details=${1:-virt-cluster-validate failed before producing JUnit output}
+    local output
+
+    if [[ -s "${RUNNER_LOG_FILE}" ]]; then
+        output=$(<"${RUNNER_LOG_FILE}")
+    else
+        output=${details}
+    fi
+
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '<testsuites name="%s"><testsuite name="%s" tests="1" failures="1" errors="0" skipped="0" time="0.000">' \
+            "${SUITE_NAME}" "${SUITE_NAME}"
+        printf '<testcase classname="%s" name="%s" time="0.000">' "${SUITE_NAME}" "${SUITE_NAME}"
+        printf '<failure message="virt-cluster-validate failed"><![CDATA[%s]]></failure>' "${output}"
+        printf '<system-out><![CDATA[%s]]></system-out>' "${output}"
+        printf '%s\n' '</testcase></testsuite></testsuites>'
+    } > "${JUNIT_FILE}"
+}
+
+emit_ctrf_progress() {
+    local total_count=0
+    local pass_count=0
+    local fail_count=0
+    local skipped_count=0
+    local duration=0
+
+    total_count=$(jq -r '.results.summary.tests // 0' "${CTRF_FILE}")
+    pass_count=$(jq -r '.results.summary.passed // 0' "${CTRF_FILE}")
+    fail_count=$(jq -r '.results.summary.failed // 0' "${CTRF_FILE}")
+    skipped_count=$(jq -r '.results.summary.skipped // 0' "${CTRF_FILE}")
+    duration=$(jq -r '
+        ((.results.summary.stop // 0) - (.results.summary.start // 0)) / 1000
+        | floor
+        | if . < 0 then 0 else . end
+    ' "${CTRF_FILE}")
+
+    echo "collecting ... collected ${total_count} items"
+    echo "${pass_count} passed, ${fail_count} failed, ${skipped_count} skipped in ${duration} seconds"
+}
+
+preflight_checks() {
+    if [[ ! -x "${VALIDATOR_GATHER}" ]]; then
+        emit_failure_artifacts "Missing must-gather entrypoint at ${VALIDATOR_GATHER}"
+        return 1
+    fi
+
+    if [[ ! -x "${VALIDATOR_BIN}" ]]; then
+        emit_failure_artifacts "Missing validator binary at ${VALIDATOR_BIN}"
+        return 1
+    fi
+
+    if [[ ! -d "${VALIDATOR_HOME}/checks.d" ]]; then
+        emit_failure_artifacts "Missing validator checks directory at ${VALIDATOR_HOME}/checks.d"
+        return 1
+    fi
+
+    mapfile -t CHECKS < <(collect_checks)
+    if [[ ${#CHECKS[@]} -eq 0 ]]; then
+        emit_failure_artifacts "No validator checks were found under ${VALIDATOR_HOME}/checks.d"
+        return 1
+    fi
+}
+
+run_dry_run() {
+    (
+        echo "Starting ${SUITE_NAME} dry-run"
+        write_dry_run_junit
+        echo "collecting ... collected ${#CHECKS[@]} items"
+        echo "0" > "${EXIT_CODE_FILE}"
+    ) 2>&1 | tee "${LOG_FILE}"
+}
+
+run_validator() {
+    (
+        local gather_rc=0
+        local validator_rc=0
+
+        echo "Starting ${SUITE_NAME} checks"
+        cd "${VALIDATOR_HOME}"
+
+        rm -f "${JUNIT_FILE}" "${RAW_JUNIT_FILE}" "${CTRF_FILE}" "${RUNNER_LOG_FILE}"
+        : > "${RUNNER_LOG_FILE}"
+
+        echo "Running through must-gather entrypoint"
+        POD_NAME="virt-cluster-validate-must-gather" \
+        MUST_GATHER="${RESULTS_DIR}" \
+        "${VALIDATOR_GATHER}" 2>> "${RUNNER_LOG_FILE}" || gather_rc=$?
+
+        if [[ -f "${RAW_JUNIT_FILE}" ]]; then
+            mv "${RAW_JUNIT_FILE}" "${JUNIT_FILE}"
+        fi
+
+        if [[ -s "${RUNNER_LOG_FILE}" ]]; then
+            echo "=== validator log ==="
+            cat "${RUNNER_LOG_FILE}"
+        fi
+
+        if [[ ! -f "${JUNIT_FILE}" ]] || [[ ! -f "${CTRF_FILE}" ]]; then
+            write_failure_junit
+            validator_rc=1
+            echo "collecting ... collected 1 items"
+            echo "0 passed, 1 failed, 0 skipped in 0 seconds"
+        else
+            emit_ctrf_progress
+        fi
+
+        if (( gather_rc != 0 )) || (( $(jq -r '.results.summary.failed // 0' "${CTRF_FILE}" 2>/dev/null || echo 0) > 0 )); then
+            validator_rc=1
+        fi
+        echo "${validator_rc}" > "${EXIT_CODE_FILE}"
+    ) 2>&1 | tee "${LOG_FILE}"
+}
+
+main() {
+    if ! preflight_checks; then
+        return 0
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        run_dry_run
+        return 0
+    fi
+
+    run_validator
+}
+
+main "$@"


### PR DESCRIPTION
Bundle the virt-cluster-validate payload in the image and wire it into
the test suite flow.

Add the validator payload to the CI image, allow
virt-cluster-validate in TEST_SUITES, and add a dedicated wrapper that
adapts validator to the expected reporting.

UI change:
https://github.com/kubevirt-ui/kubevirt-plugin/pull/4384
