### PR TITLE
CNV-92884: support `PRIMARY_NETWORK_BINDING_PLUGIN` for network conformance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,21 @@ In this case, `storageRWXFileSystem` should be set.
 
 **Note** If the `storageSnapshot` storage capability is not passed, tests that are requiring snapshots will fail with error. The snapshot tests are not skipped because they are a core functionality of OpenShift Virtualization.
 
+#### Primary Network Binding Plugin
+When running the `network` test suite with a custom network binding plugin, the `PRIMARY_NETWORK_BINDING_PLUGIN` environment variable can be set to the name of the binding plugin to test. This passes the `--primary-network-binding-plugin` flag to the upstream KubeVirt conformance tests, enabling CNI vendors and network binding plugin authors to certify their implementations.
+
+When this parameter is set:
+- The `netCustomBindingPlugins` label filter exclusion is removed (these tests are now relevant)
+- Masquerade-specific tests (labeled `interface-ports`, `network-cidr`, `IPv6`) are excluded, as they are not applicable when a non-masquerade binding plugin is in use
+
+Example:
+```bash
+$ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
+    -e TEST_SUITES=network \
+    -e PRIMARY_NETWORK_BINDING_PLUGIN=my-binding-plugin \
+    ${OCP_VIRT_VALIDATION_IMAGE} generate
+```
+
 #### Dry Run
 In order to see which tests are going to be run, without actually executing them on the cluster, a `DRY_RUN` environment variable can be set:
 ```bash

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -21,6 +21,7 @@ STORAGE_CAPABILITIES=${STORAGE_CAPABILITIES:-""}
 ACCEPT_WINDOWS_EULA=${ACCEPT_WINDOWS_EULA:-"false"}
 WIN_IMAGE_DOWNLOAD_URL=${WIN_IMAGE_DOWNLOAD_URL:-""}
 TEKTON_PIPELINE_VERSION=${TEKTON_PIPELINE_VERSION:-""}
+PRIMARY_NETWORK_BINDING_PLUGIN=${PRIMARY_NETWORK_BINDING_PLUGIN:-""}
 
 # Calculate storage size based on test suites (2Gi per suite, 10Gi for tier2)
 IFS=',' read -ra TEST_SUITES_ARRAY <<< "${TEST_SUITES}"
@@ -225,6 +226,8 @@ spec:
               value: "${WIN_IMAGE_DOWNLOAD_URL}"
             - name: TEKTON_PIPELINE_VERSION
               value: "${TEKTON_PIPELINE_VERSION}"
+            - name: PRIMARY_NETWORK_BINDING_PLUGIN
+              value: "${PRIMARY_NETWORK_BINDING_PLUGIN}"
           volumeMounts:
             - name: results-volume
               mountPath: /results

--- a/manifests/run/generate.sh
+++ b/manifests/run/generate.sh
@@ -113,6 +113,13 @@ if [[ -n "${STORAGE_CAPABILITIES}" ]]; then
   fi
 fi
 
+# Validate PRIMARY_NETWORK_BINDING_PLUGIN format (must be a valid plugin name: alphanumeric, '-', '.')
+if [[ -n "${PRIMARY_NETWORK_BINDING_PLUGIN}" && ! "${PRIMARY_NETWORK_BINDING_PLUGIN}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+  echo "Error: Invalid PRIMARY_NETWORK_BINDING_PLUGIN value: '${PRIMARY_NETWORK_BINDING_PLUGIN}'"
+  echo "Expected: a valid plugin name (alphanumeric characters, '-', '.', must start with alphanumeric)"
+  exit 1
+fi
+
 
 # Namespace
 cat <<EOF

--- a/progress_watcher/progress_watcher.go
+++ b/progress_watcher/progress_watcher.go
@@ -549,6 +549,11 @@ func runDryRunForSuite(suiteName, resultsDir string) int {
 	}
 
 	// Add suite-specific environment variables
+	if suiteName == "network" {
+		if bindingPlugin := os.Getenv("PRIMARY_NETWORK_BINDING_PLUGIN"); bindingPlugin != "" {
+			env = append(env, fmt.Sprintf("PRIMARY_NETWORK_BINDING_PLUGIN=%s", bindingPlugin))
+		}
+	}
 	if suiteName == "tier2" {
 		// tier2 needs storage class and subscription info
 		if defaultStorageClass := os.Getenv("DEFAULT_STORAGE_CLASS"); defaultStorageClass != "" {

--- a/scripts/kubevirt/test-kubevirt.sh
+++ b/scripts/kubevirt/test-kubevirt.sh
@@ -106,8 +106,18 @@ label_filter=()
 
 skip_tests_labels_file="${SCRIPT_DIR}/config/dont_run_tests_labels.json"
 for ginkgo_label_name in $(jq -r '.[].ginkgo_label_name' $skip_tests_labels_file); do
+  # When a primary network binding plugin is specified for network tests,
+  # include netCustomBindingPlugins tests (we are testing a custom binding plugin)
+  if [ "${SIG}" == "network" ] && [ -n "${PRIMARY_NETWORK_BINDING_PLUGIN}" ] && [ "$ginkgo_label_name" == "netCustomBindingPlugins" ]; then
+    continue
+  fi
   label_filter+=( "!($ginkgo_label_name)" )
 done
+
+# When a primary network binding plugin is in use, exclude masquerade-specific tests
+if [ "${SIG}" == "network" ] && [ -n "${PRIMARY_NETWORK_BINDING_PLUGIN}" ]; then
+  label_filter+=( "!(interface-ports)" "!(network-cidr)" "!(IPv6)" )
+fi
 
 # If TEST_FOCUS is set, remove any overlapping entries from skip list so focused tests run
 if [ -n "${TEST_FOCUS}" ]; then
@@ -214,6 +224,13 @@ fi
 
 label_filter_str="--ginkgo.label-filter=${label_filter_joined}"
 
+# Build primary network binding plugin flag for network tests
+BINDING_PLUGIN_FLAG=""
+if [ "${SIG}" == "network" ] && [ -n "${PRIMARY_NETWORK_BINDING_PLUGIN}" ]; then
+  BINDING_PLUGIN_FLAG="--primary-network-binding-plugin=${PRIMARY_NETWORK_BINDING_PLUGIN}"
+  echo "Using primary network binding plugin: ${PRIMARY_NETWORK_BINDING_PLUGIN}"
+fi
+
 # Apply disk-images-provider if running storage tests (but not in dry-run mode)
 if [ "${SIG}" == "storage" ] && [ -z "${DRY_RUN_FLAG}" ]; then
     apply_disk_images_provider
@@ -239,6 +256,7 @@ echo "Starting ${SIG} tests 🧪"
     -utility-container-tag="${KUBEVIRT_RELEASE}" \
     ${GINKGO_FLAKE} \
     ${DRY_RUN_FLAG} \
+    ${BINDING_PLUGIN_FLAG} \
     "${skip_arg}"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/${SIG}-log.txt &
 
 # Store the PID for cleanup

--- a/scripts/kubevirt/test-kubevirt.sh
+++ b/scripts/kubevirt/test-kubevirt.sh
@@ -225,9 +225,9 @@ fi
 label_filter_str="--ginkgo.label-filter=${label_filter_joined}"
 
 # Build primary network binding plugin flag for network tests
-BINDING_PLUGIN_FLAG=""
+BINDING_PLUGIN_ARGS=()
 if [ "${SIG}" == "network" ] && [ -n "${PRIMARY_NETWORK_BINDING_PLUGIN}" ]; then
-  BINDING_PLUGIN_FLAG="--primary-network-binding-plugin=${PRIMARY_NETWORK_BINDING_PLUGIN}"
+  BINDING_PLUGIN_ARGS+=("--primary-network-binding-plugin=${PRIMARY_NETWORK_BINDING_PLUGIN}")
   echo "Using primary network binding plugin: ${PRIMARY_NETWORK_BINDING_PLUGIN}"
 fi
 
@@ -256,7 +256,7 @@ echo "Starting ${SIG} tests 🧪"
     -utility-container-tag="${KUBEVIRT_RELEASE}" \
     ${GINKGO_FLAKE} \
     ${DRY_RUN_FLAG} \
-    ${BINDING_PLUGIN_FLAG} \
+    "${BINDING_PLUGIN_ARGS[@]}" \
     "${skip_arg}"; echo $? > "${ARTIFACTS}/.exit_code") 2>&1 | tee ${ARTIFACTS}/${SIG}-log.txt &
 
 # Store the PID for cleanup


### PR DESCRIPTION
Allow CNI vendors and binding plugin authors to certify their implementations by passing `--primary-network-binding-plugin` to the upstream KubeVirt test binary. When the parameter is set, masquerade- specific tests (`interface-ports`, `network-cidr`, `IPv6`) are excluded and `netCustomBindingPlugins` tests are included.

verified with passt binding: https://kubevirt.io/user-guide/network/net_binding_plugins/passt/
on CNV v5.0.0.rhel9-28