### PR TITLE
fix: remove obsolete baseDvNamespace/baseDvStorageClass pipeline params

### DIFF
--- a/manifests/windows/golden-image.yaml
+++ b/manifests/windows/golden-image.yaml
@@ -340,8 +340,6 @@ spec:
       value: "true"
     - name: baseDvName
       value: "win2k22"
-    - name: baseDvNamespace
-      value: "validation-os-images"
     - name: instanceTypeName
       value: "u1.large"
     - name: instanceTypeKind
@@ -352,9 +350,6 @@ spec:
       value: "win2k22-autounattend"
     - name: isoDVName
       value: "win2k22-iso"
-    # Optional: Set storage class. If omitted, the cluster default is used.
-    # - name: baseDvStorageClass
-    #   value: "my-storage-class"
   taskRunSpecs:
     - pipelineTaskName: modify-windows-iso-file
       podTemplate:

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -133,8 +133,6 @@ spec:
       value: "${ACCEPT_WINDOWS_EULA}"
     - name: baseDvName
       value: "${GOLDEN_IMAGE_NAME}"
-    - name: baseDvNamespace
-      value: "${GOLDEN_IMAGE_NAMESPACE}"
     - name: instanceTypeName
       value: "${INSTANCE_TYPE}"
     - name: instanceTypeKind
@@ -143,8 +141,6 @@ spec:
       value: "windows.2k22"
     - name: autounattendConfigMapName
       value: "${AUTOUNATTEND_CM_NAME}"
-    - name: baseDvStorageClass
-      value: "${STORAGE_CLASS}"
     - name: isoDVName
       value: "${GOLDEN_IMAGE_NAME}-iso"
   taskRunSpecs:


### PR DESCRIPTION
## Summary
- Remove `baseDvNamespace` and `baseDvStorageClass` from PipelineRun params in both `setup-golden-image.sh` and `golden-image.yaml`
- These parameters were dropped in `windows-efi-installer v4.22.2`; since the default `PIPELINE_VERSION` resolves `>=v4.21.0` to v4.22.2, Tekton strictly rejects the unknown params and the PipelineRun fails immediately
- Safe for all pipeline versions — these were never public API params (v4.21.0 silently ignored them); the pipeline derives namespace from the PipelineRun context and auto-detects the default StorageClass

Resolves: [CNV-94319](https://redhat.atlassian.net/browse/CNV-94319)

## Test plan
- [ ] Verify PipelineRun succeeds with `>=v4.21.0` (resolves to v4.22.2)
- [ ] Verify PipelineRun succeeds with explicit `v4.21.0`
- [ ] Confirm CI passes (connected + disconnected)

