### PR TITLE
fix: remove obsolete baseDvNamespace/baseDvStorageClass pipeline params

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The tool downloads a Windows Server 2022 ISO, runs a Tekton pipeline to install 
 - **OpenShift Pipelines operator** must be installed
 - **Internet access** to download the ISO and fetch the pipeline from Artifact Hub
 - **Sufficient storage** (~64GB recommended)
-- **`STORAGE_CLASS`** set to a valid storage class (required by the Windows setup script)
+- **`STORAGE_CLASS`** set to a valid storage class
 
 **Usage:**
 ```bash

--- a/manifests/windows/golden-image.yaml
+++ b/manifests/windows/golden-image.yaml
@@ -340,8 +340,6 @@ spec:
       value: "true"
     - name: baseDvName
       value: "win2k22"
-    - name: baseDvNamespace
-      value: "validation-os-images"
     - name: instanceTypeName
       value: "u1.large"
     - name: instanceTypeKind
@@ -352,9 +350,6 @@ spec:
       value: "win2k22-autounattend"
     - name: isoDVName
       value: "win2k22-iso"
-    # Optional: Set storage class. If omitted, the cluster default is used.
-    # - name: baseDvStorageClass
-    #   value: "my-storage-class"
   taskRunSpecs:
     - pipelineTaskName: modify-windows-iso-file
       podTemplate:

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -133,8 +133,6 @@ spec:
       value: "${ACCEPT_WINDOWS_EULA}"
     - name: baseDvName
       value: "${GOLDEN_IMAGE_NAME}"
-    - name: baseDvNamespace
-      value: "${GOLDEN_IMAGE_NAMESPACE}"
     - name: instanceTypeName
       value: "${INSTANCE_TYPE}"
     - name: instanceTypeKind
@@ -143,8 +141,6 @@ spec:
       value: "windows.2k22"
     - name: autounattendConfigMapName
       value: "${AUTOUNATTEND_CM_NAME}"
-    - name: baseDvStorageClass
-      value: "${STORAGE_CLASS}"
     - name: isoDVName
       value: "${GOLDEN_IMAGE_NAME}-iso"
   taskRunSpecs:


### PR DESCRIPTION
## Summary
- Remove `baseDvNamespace` and `baseDvStorageClass` from PipelineRun params in `setup-golden-image.sh`, `golden-image.yaml`, and related docs
- These parameters were **never part of the pipeline's public API** in any version — confirmed via ArtifactHub API for both v4.21.0 and v4.22.2, Tekton silently ignored the extras on lenient configurations (`enable-api-fields: beta`) but rejects them on stricter ones
- Remove stale `STORAGE_CLASS` guard and prerequisites in the Windows setup script since the PipelineRun no longer consumes it
- `STORAGE_CLASS` is still used by the rest of the tool (entrypoint.sh, tier2, storage config) — only the Windows setup script no longer needs it

Resolves: [CNV-94319](https://redhat.atlassian.net/browse/CNV-94319)

## Test plan
- [x] Verified v4.21.0 pipeline spec (12 params, neither `baseDvNamespace` nor `baseDvStorageClass` present)
- [x] Verified v4.22.2 pipeline spec (same 12 params)
- [x] Full pipeline end-to-end with `TEKTON_PIPELINE_VERSION=v4.21.0`
- [x] PipelineRun acceptance with `>=v4.21.0` (resolves to v4.22.2)
- [x] CI passes (connected + disconnected)

