### PR TITLE
fix: propagate Windows setup failures when ACCEPT_WINDOWS_EULA=true

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -408,9 +408,9 @@ fi
 #   - Tool-created: ACCEPT_WINDOWS_EULA=true → runs pipeline
 # Exit code contract with setup-golden-image.sh (must stay in sync):
 #   0              = success or expected skip (BYOI ready, EULA not set)
-#   EXIT_WIN_SKIP  = prerequisite missing (e.g. Pipelines not installed) — skip gracefully
+#   EXIT_WINDOWS_SKIP = prerequisite missing (e.g. Pipelines not installed) — skip gracefully
 #   anything else  = real failure (pipeline ran and failed, timeout, config error) — hard fail
-readonly EXIT_WIN_SKIP=2
+readonly EXIT_WINDOWS_SKIP=2
 
 WINDOWS_SETUP_SCRIPT="${SCRIPT_DIR}/windows/setup-golden-image.sh"
 if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
@@ -424,7 +424,7 @@ if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
     0)
       # Success or expected skip (BYOI ready, EULA not set)
       ;;
-    "${EXIT_WIN_SKIP}")
+    "${EXIT_WINDOWS_SKIP}")
       # Missing prerequisite: skip gracefully
       # setup-golden-image.sh's EXIT trap already cleaned up its resources
       echo "WARNING: Windows golden image setup skipped (missing prerequisite). Windows tests will be skipped."

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -406,18 +406,38 @@ fi
 # Run the Windows setup script which handles both paths:
 #   - BYOI: DataSource exists and is Ready → exits immediately
 #   - Tool-created: ACCEPT_WINDOWS_EULA=true → runs pipeline
+# Exit code contract with setup-golden-image.sh (must stay in sync):
+#   0              = success or expected skip (BYOI ready, EULA not set)
+#   EXIT_WIN_SKIP  = prerequisite missing (e.g. Pipelines not installed) — skip gracefully
+#   anything else  = real failure (pipeline ran and failed, timeout, config error) — hard fail
+readonly EXIT_WIN_SKIP=2
+
 WINDOWS_SETUP_SCRIPT="${SCRIPT_DIR}/windows/setup-golden-image.sh"
 if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
   export STORAGE_CLASS
   export WIN_IMAGE_DOWNLOAD_URL
   export TEKTON_PIPELINE_VERSION
   export ACCEPT_WINDOWS_EULA
-  if ! bash "${WINDOWS_SETUP_SCRIPT}"; then
-    echo "WARNING: Windows golden image setup failed. Windows tests will be skipped."
-    echo "All other test suites will continue normally."
-    cleanup_windows_resources
-    unset ACCEPT_WINDOWS_EULA
-  fi
+  WINDOWS_SETUP_EXIT=0
+  bash "${WINDOWS_SETUP_SCRIPT}" || WINDOWS_SETUP_EXIT=$?
+  case $WINDOWS_SETUP_EXIT in
+    0)
+      # Success or expected skip (BYOI ready, EULA not set)
+      ;;
+    "${EXIT_WIN_SKIP}")
+      # Missing prerequisite: skip gracefully
+      # setup-golden-image.sh's EXIT trap already cleaned up its resources
+      echo "WARNING: Windows golden image setup skipped (missing prerequisite). Windows tests will be skipped."
+      echo "All other test suites will continue normally."
+      unset ACCEPT_WINDOWS_EULA
+      ;;
+    *)
+      # Pipeline or setup failure: hard fail so CI detects the problem
+      # setup-golden-image.sh's EXIT trap already cleaned up its resources
+      echo "ERROR: Windows golden image setup failed (exit ${WINDOWS_SETUP_EXIT}). Aborting validation."
+      exit 1
+      ;;
+  esac
 fi
 
 # Start progress watcher in background AFTER storage config is set

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -505,7 +505,7 @@ if ! oc get crd pipelines.tekton.dev &>/dev/null; then
   echo "  1. Go to OperatorHub in the OpenShift Console"
   echo "  2. Search for 'Red Hat OpenShift Pipelines'"
   echo "  3. Install the operator"
-  exit 2
+  exit ${EXIT_WINDOWS_SKIP}
 fi
 echo "OpenShift Pipelines operator is installed"
 

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -33,6 +33,12 @@ source "${SCRIPT_DIR}/../funcs.sh"
 GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
 GOLDEN_IMAGE_NAME="${GOLDEN_IMAGE_NAME:-win2k22}"
 
+# Exit code contract (must stay in sync with entrypoint.sh):
+#   0 = success or expected skip (BYOI ready, EULA not set)
+#   2 = prerequisite missing (e.g. Pipelines operator not installed) — caller skips gracefully
+#   1 = real failure (pipeline ran and failed, timeout, config error) — caller hard-fails
+readonly EXIT_WINDOWS_SKIP=2
+
 DEFAULT_WIN_IMAGE_URL="https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
 WIN_IMAGE_URL="${WIN_IMAGE_DOWNLOAD_URL:-${DEFAULT_WIN_IMAGE_URL}}"
 
@@ -74,6 +80,34 @@ cleanup_autounattend_cm() {
 
 cleanup_namespace() {
   cleanup_golden_image_resources "${GOLDEN_IMAGE_NAMESPACE}"
+}
+
+dump_windows_debug_info() {
+  echo "=== Windows Setup Debug Info ==="
+
+  if oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
+    echo "--- PipelineRuns ---"
+    oc get pipelinerun -n "${GOLDEN_IMAGE_NAMESPACE}" 2>/dev/null || true
+
+    if [ -n "${PIPELINE_RUN_NAME:-}" ]; then
+      echo "--- PipelineRun ${PIPELINE_RUN_NAME} conditions ---"
+      oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions}' 2>/dev/null | jq . || true
+    fi
+
+    echo "--- TaskRuns ---"
+    oc get taskrun -n "${GOLDEN_IMAGE_NAMESPACE}" \
+      -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' \
+      2>/dev/null || true
+
+    echo "--- Events (last 20) ---"
+    oc get events -n "${GOLDEN_IMAGE_NAMESPACE}" \
+      --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+  else
+    echo "Namespace ${GOLDEN_IMAGE_NAMESPACE} does not exist — no resources to dump"
+  fi
+
+  echo "=== End Debug Info ==="
 }
 
 run_pipeline() {
@@ -456,6 +490,11 @@ fi
 
 echo "Microsoft EULA accepted by user"
 
+# Set trap early so dump_windows_debug_info fires for real failures.
+# Exit ${EXIT_WINDOWS_SKIP} (prerequisite missing) is a routine skip — skip the dump.
+CREATED_PIPELINE_SA=false
+trap 'exit_code=$?; [ $exit_code -ne 0 ] && [ $exit_code -ne '"${EXIT_WINDOWS_SKIP}"' ] && dump_windows_debug_info; cleanup_pipeline_sa; cleanup_autounattend_cm; if [ $exit_code -ne 0 ]; then cleanup_namespace; fi' EXIT
+
 echo "Checking if OpenShift Pipelines operator is installed..."
 if ! oc get crd pipelines.tekton.dev &>/dev/null; then
   echo "WARNING: OpenShift Pipelines operator is not installed."
@@ -466,13 +505,11 @@ if ! oc get crd pipelines.tekton.dev &>/dev/null; then
   echo "  1. Go to OperatorHub in the OpenShift Console"
   echo "  2. Search for 'Red Hat OpenShift Pipelines'"
   echo "  3. Install the operator"
-  exit 1
+  exit 2
 fi
 echo "OpenShift Pipelines operator is installed"
 
 # Tool-managed: create namespace, RBAC, run pipeline, create DataSource, cleanup on completion
-CREATED_PIPELINE_SA=false
-trap 'exit_code=$?; cleanup_pipeline_sa; cleanup_autounattend_cm; if [ $exit_code -ne 0 ]; then cleanup_namespace; fi' EXIT
 
 echo "Ensuring namespace ${GOLDEN_IMAGE_NAMESPACE} exists..."
 if ! oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then


### PR DESCRIPTION
When a user enables Windows Server 2022 testing, a silent success is more harmful than an explicit failure: if the Windows image setup fails and the tool still reports everything as passing, the user has no indication that Windows tests never ran. This PR intends to address that.

## Summary

- Fixes [CNV-94319](https://redhat.atlassian.net/browse/CNV-94319): Windows PipelineRun failures were silently swallowed by the [CNV-92678](https://redhat.atlassian.net/browse/CNV-92678) fix, causing CI to report success with Windows tests never having run
- Introduces differentiated exit codes so CI can distinguish "missing prerequisite" (graceful skip) from "pipeline actually failed" (hard fail)
- Adds `dump_windows_debug_info()` to capture PipelineRun/TaskRun/event state on failure

## What this PR does / why we need it

The fix for [CNV-92678](https://redhat.atlassian.net/browse/CNV-92678) (commit `2fa291f`) wrapped all Windows setup failures in a WARNING+skip pattern. This was correct for the "Pipelines operator not installed" case, but it also silently swallowed real PipelineRun failures — CI would pass with Windows tests silently not run ([CNV-94319](https://redhat.atlassian.net/browse/CNV-94319)).

**Exit code contract** introduced in `setup-golden-image.sh`:
- `EXIT_WINDOWS_SKIP=2`: prerequisite missing (Pipelines not installed) → caller skips gracefully, other suites continue — preserves the [CNV-92678](https://redhat.atlassian.net/browse/CNV-92678) fix
- exit 1: real failure (PipelineRun failed, timeout, config error) → caller hard-fails so CI detects the problem

`entrypoint.sh` uses a `case` statement on the exit code, replacing the previous `if !` pattern. New exit codes map to named constants (`EXIT_WIN_SKIP=2`) with the contract documented in both files.

**Debug improvements:**
- `dump_windows_debug_info()`: logs PipelineRuns, TaskRuns (now at namespace level, not gated on `PIPELINE_RUN_NAME`), and the last 20 namespace events
- Trap moved before the Pipelines check so the debug dump fires for all real failures
- Debug dump skipped for routine exit-2 skips to avoid misleading "failure investigation" noise in logs

Resolves: [CNV-94319](https://redhat.atlassian.net/browse/CNV-94319)
Related: [CNV-92678](https://redhat.atlassian.net/browse/CNV-92678)