### PR TITLE
fix(windows): redesign golden image pipeline for reliable OpenSSH install

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Do sanity checks
         run: make build
+
+      - name: Check Windows ConfigMap sync
+        run: bash scripts/check-ps1-sync.sh

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} -e DRY_RU
 
 The validation checkup supports optional Windows VM testing. There are two options:
 
+**Note:** Both options below require **internet access** (connected cluster). For disconnected environments, provide your own pre-built Windows golden image (BYOI) with SSH and guest agent pre-installed. See [`disconnected/README.md`](disconnected/README.md) for details.
+
 #### Option 1: Customer-Managed (Apply Manifest)
 
 A ready-to-use manifest is provided that creates a Windows Server 2022 golden image from scratch using a Tekton pipeline. It includes namespace, RBAC, sysprep configuration, and a PipelineRun — single `oc apply`, full automation.
@@ -271,7 +273,7 @@ A ready-to-use manifest is provided that creates a Windows Server 2022 golden im
 **Prerequisites:**
 - **OpenShift Pipelines operator** must be installed
 - **cluster-admin** access (for privileged SCC assignment)
-- **Internet access** to download the Windows ISO and fetch the pipeline from Artifact Hub (see [`disconnected/README.md`](disconnected/README.md) for air-gapped setups)
+- **Internet access** to download the Windows ISO and fetch the pipeline from Artifact Hub
 - **Sufficient storage** (~64GB recommended for the Windows image)
 
 **Setup:**
@@ -341,8 +343,9 @@ $ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
 2. Creates the `validation-os-images` namespace, RBAC, and runs the `windows-efi-installer` Tekton pipeline
 3. The pipeline downloads the ISO and installs Windows Server 2022 with OpenSSH, QEMU guest agent, and firewall disabled
 4. A DataSource (`win2k22`) is created backed by the output PVC
-5. The tier2 test suite runs tests matching `@pytest.mark.conformance`; when no golden image is available, tests with `@pytest.mark.windows` are excluded
-6. After tests complete, the entire `validation-os-images` namespace is deleted
+5. A temporary VM (`win-ssh-verify-*`) boots from the golden image to verify SSH (port 22) is reachable. If verification fails the entire checkup aborts — check `C:\post-update.log` inside the golden image for diagnosis.
+6. The tier2 test suite runs tests matching `@pytest.mark.conformance`; when no golden image is available, tests with `@pytest.mark.windows` are excluded
+7. After tests complete, the entire `validation-os-images` namespace is deleted
 
 **Note:** The initial Windows image creation takes approximately 1-2 hours (up to 3 hours on slow networks).
 

--- a/disconnected/README.md
+++ b/disconnected/README.md
@@ -348,75 +348,39 @@ The script will:
 
 ## Windows Testing in Disconnected Environments
 
-Windows testing requires additional setup in disconnected environments because the `windows-efi-installer` Tekton pipeline normally uses the hub resolver to fetch the pipeline and tasks from Artifact Hub, which requires internet access.
+The automated Windows golden image creation (`ACCEPT_WINDOWS_EULA=true`) requires internet access to download the Windows ISO and fetch the Tekton pipeline from Artifact Hub. It is **not supported** in disconnected environments.
 
-**Recommended:** Apply `manifests/windows/golden-image.yaml` once. Pre-install the Tekton pipeline (see Step 2 below), set `winImageDownloadURL` to your internal ISO mirror in the manifest, and wait for the pipeline to finish. Then run the checkup **without** `ACCEPT_WINDOWS_EULA` — the tool detects the existing DataSource and skips the pipeline entirely, avoiding repeated downloads and rebuilds.
+To run Windows tests on a disconnected cluster, provide your own pre-built golden image (BYOI):
 
-The steps below describe the **alternative (ephemeral)** path using `ACCEPT_WINDOWS_EULA=true`, which rebuilds the golden image on every run.
+### Requirements
 
-### Prerequisites for Disconnected Windows Testing
+Your Windows image must have:
+- **OpenSSH server** installed and set to start automatically (port 22)
+- **QEMU guest agent** installed
+- **Administrator** account with password `Administrator`
+- **Windows Firewall** disabled
 
-1. **OpenShift Pipelines operator** installed on the cluster
-2. **Windows Server 2022 ISO** available on an accessible internal server
-3. **Tekton pipeline and tasks** pre-installed manually
+### Setup
 
-### Step 1: Download the Windows Server 2022 ISO
+1. Prepare a Windows Server 2022 image with the requirements above (using your own tooling, ISO, or existing image).
 
-Download the Windows Server 2022 evaluation ISO from Microsoft on a connected machine and host it on an internal HTTP server accessible from the cluster:
-
-```bash
-# On connected machine
-curl -L -o SERVER_EVAL_x64FRE_en-us.iso "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
-
-# Copy to your internal HTTP server
-scp SERVER_EVAL_x64FRE_en-us.iso user@internal-server:/var/www/html/images/
-```
-
-### Step 2: Pre-install the Tekton Pipeline
-
-Since the hub resolver cannot fetch from Artifact Hub in disconnected environments, you must manually install the `windows-efi-installer` pipeline and its tasks.
-
-Download the pipeline manifests from a connected machine:
-```bash
-# On connected machine
-curl -L -o windows-efi-installer.yaml \
-  "https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/main/release/pipelines/windows-efi-installer/windows-efi-installer.yaml"
-
-curl -L -o windows-efi-installer-tasks.yaml \
-  "https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/main/release/tasks/windows-efi-installer/windows-efi-installer-tasks.yaml"
-
-curl -L -o windows-efi-installer-configmaps.yaml \
-  "https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/main/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml"
-```
-
-Transfer and apply to the disconnected cluster:
+2. Create the namespace with the required Pod Security label:
 ```bash
 oc create namespace validation-os-images
-oc label namespace validation-os-images app=ocp-virt-validation
 oc label namespace validation-os-images pod-security.kubernetes.io/enforce=privileged
-oc apply -f windows-efi-installer-tasks.yaml -n validation-os-images
-oc apply -f windows-efi-installer-configmaps.yaml -n validation-os-images
-oc apply -f windows-efi-installer.yaml -n validation-os-images
 ```
 
-Alternatively, get the manifests from Artifact Hub:
-- https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer
-
-### Step 3: Run the Checkup with Custom Windows ISO URL
-
-When running the validation checkup, specify your internal Windows ISO URL:
-
+3. Edit `manifests/windows/golden-image.yaml`: comment out the Method 1 (Tekton pipeline) section and uncomment the Method 2 DataVolume section. Set the source to your image location — the manifest documents all supported import options (HTTP URL, container registry, PVC clone, or `virtctl image-upload`). Then apply it:
 ```bash
-$ podman run -e OCP_VIRT_VALIDATION_IMAGE=${OCP_VIRT_VALIDATION_IMAGE} \
-    -e ACCEPT_WINDOWS_EULA=true \
-    -e STORAGE_CLASS=<your-storage-class> \
-    -e WIN_IMAGE_DOWNLOAD_URL="http://internal-server.example.com/images/SERVER_EVAL_x64FRE_en-us.iso" \
-    ${OCP_VIRT_VALIDATION_IMAGE} generate
+oc apply -f manifests/windows/golden-image.yaml
 ```
 
-### Notes for Disconnected Windows Testing
+4. Verify the DataSource is Ready:
+```bash
+oc get datasource win2k22 -n validation-os-images -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# Should print: True
+```
 
-- The pipeline output PVC backs a `win2k22` DataSource in a custom `validation-os-images` namespace created by the tool -- no intermediate VMs or snapshots
-- The image creation takes approximately 1-2 hours on first run (up to 3 hours on slow networks)
-- With `ACCEPT_WINDOWS_EULA=true`, each run rebuilds the golden image from scratch and cleans up on completion
-- If the hub resolver fails (due to no internet), the checkup will provide instructions for manual pipeline installation
+6. Run the validation tool **without** `ACCEPT_WINDOWS_EULA`. The tool detects the existing DataSource and runs Windows tests automatically.
+
+**Important:** Do **not** set `ACCEPT_WINDOWS_EULA=true` on disconnected clusters. The tool-managed path requires internet access; it detects the missing hub resolver and skips Windows tests gracefully, but other pipeline failures (ISO download, timeout, SSH verification) will abort the entire validation run.

--- a/manifests/windows/golden-image.yaml
+++ b/manifests/windows/golden-image.yaml
@@ -218,6 +218,20 @@ data:
           </UserData>
         </component>
       </settings>
+      <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <ComputerName>*</ComputerName>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <RunSynchronous>
+            <RunSynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <Path>reg add "HKLM\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" /f</Path>
+              <Description>Suppress network location dialog</Description>
+            </RunSynchronousCommand>
+          </RunSynchronous>
+        </component>
+      </settings>
       <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <InputLocale>0409:00000409</InputLocale>
@@ -262,21 +276,99 @@ data:
       </settings>
     </unattend>
   post-update.ps1: |
+    Start-Transcript -Path "C:\post-update.log" -Force
+    $sshInstalled = $false
     try {
-      $ErrorActionPreference = 'Stop'
+      # Install QEMU guest agent (with timeout to avoid hangs)
+      $gaJob = Start-Job { $p = Start-Process msiexec -Wait -PassThru -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /norestart"; $p.ExitCode }
+      if (-not (Wait-Job $gaJob -Timeout 120)) {
+        Stop-Job $gaJob; Remove-Job $gaJob -Force
+        Write-Host "WARNING: QEMU guest agent installer timed out after 120s -- continuing"
+      } else {
+        $exitCode = Receive-Job $gaJob; Remove-Job $gaJob
+        if ($exitCode -ne 0 -and $exitCode -ne 3010) {
+          Write-Host "WARNING: QEMU guest agent installer exited $exitCode -- continuing"
+        }
+      }
 
-      # Install QEMU guest agent
-      Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+      # Disable Windows Firewall first (ensures VM is reachable regardless of SSH outcome)
+      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False -ErrorAction Stop
 
-      # Install and start OpenSSH server
-      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-      Set-Service -Name sshd -StartupType Automatic
-      Start-Service sshd
+      # Wait for network connectivity before OpenSSH install (DHCP + DNS can take time during OOBE)
+      Write-Host "Waiting for network connectivity..."
+      $netReady = $false
+      for ($i = 0; $i -lt 30; $i++) {
+        $addrs = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+          Where-Object { $_.IPAddress -ne '127.0.0.1' -and $_.PrefixOrigin -ne 'WellKnown' }
+        if ($addrs) {
+          Write-Host "IPv4 address acquired: $($addrs[0].IPAddress) on $($addrs[0].InterfaceAlias)"
+          try {
+            [System.Net.Dns]::GetHostAddresses('github.com') | Out-Null
+            Write-Host "DNS resolution verified"
+            $netReady = $true
+            break
+          } catch {
+            Write-Host "  DNS not ready yet (attempt $i)..."
+          }
+        } else {
+          Write-Host "  No IPv4 address yet (attempt $i)..."
+        }
+        Start-Sleep -Seconds 5
+      }
+      if (-not $netReady) {
+        Write-Host "WARNING: Network not fully ready after 150s -- OpenSSH online methods may fail"
+      }
 
-      # Disable Windows Firewall entirely
-      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+      # Install OpenSSH server with fallback methods
+      try {
+        Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -LimitAccess -ErrorAction Stop
+        Write-Host "OpenSSH installed via local capability store (-LimitAccess)"
+      } catch {
+        Write-Host "OpenSSH local install (-LimitAccess) failed: $($_). Trying online method (300s timeout)..."
+        try {
+          $job = Start-Job { Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop }
+          if (-not (Wait-Job $job -Timeout 300)) {
+            Stop-Job $job; Remove-Job $job -Force
+            throw "Add-WindowsCapability online timed out after 300s"
+          }
+          Receive-Job $job -ErrorAction Stop; Remove-Job $job
+          Write-Host "OpenSSH installed via Windows Update (online)"
+        } catch {
+          Write-Host "OpenSSH online install failed: $($_). Trying GitHub MSI fallback..."
+          try {
+            # Win32-OpenSSH stable releases only ship .zip archives; MSI installers are Preview-only.
+            # When updating, change both the URL and expectedHash together.
+            # Hash: SHA-256 of the official GitHub release artifact.
+            # Verify with: (Get-FileHash OpenSSH-Win64-v10.0.0.0.msi -Algorithm SHA256).Hash
+            $url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi'
+            $expectedHash = 'ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9'
+            $msi = "$env:TEMP\OpenSSH-Win64.msi"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+            Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing -TimeoutSec 120 -ErrorAction Stop
+            $actualHash = (Get-FileHash $msi -Algorithm SHA256).Hash.ToLower()
+            if ($actualHash -ne $expectedHash) {
+              throw "OpenSSH MSI hash mismatch (expected $expectedHash, got $actualHash)"
+            }
+            $msiProc = Start-Process msiexec -Wait -PassThru -ArgumentList "/i $msi /qn /norestart"
+            if ($msiProc.ExitCode -ne 0 -and $msiProc.ExitCode -ne 3010) {
+              throw "OpenSSH MSI installer failed with exit code $($msiProc.ExitCode)"
+            }
+            Write-Host "OpenSSH installed via GitHub MSI (exit code: $($msiProc.ExitCode))"
+          } catch {
+            throw "FATAL: All OpenSSH installation methods failed. Last error: $($_)"
+          }
+        }
+      }
 
-      $ErrorActionPreference = 'Continue'
+      Set-Service -Name sshd -StartupType Automatic -ErrorAction Stop
+      Start-Service sshd -ErrorAction Stop
+      $sshdStatus = (Get-Service sshd).Status
+      if ($sshdStatus -ne 'Running') {
+        throw "FATAL: sshd service is not running (status: $sshdStatus)"
+      }
+      Write-Host "OpenSSH sshd service is running and set to auto-start"
+      $sshInstalled = $true
+
 
       # Suppress network location wizard and set profile
       New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
@@ -285,11 +377,12 @@ data:
       # Disable Server Manager auto-launch
       Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Value 1
 
-      # Cleanup for smaller image
+      # Cleanup for smaller image (with timeouts to avoid hangs)
       Vssadmin delete shadows /all /quiet 2>$null
       Remove-Item -Path $env:Temp -Recurse -Force -ErrorAction SilentlyContinue
       powercfg -h off 2>$null
 
+      # DISM can hang -- run with a timeout
       $dismJob = Start-Job { dism.exe /online /Cleanup-Image /StartComponentCleanup }
       if (-not (Wait-Job $dismJob -Timeout 300)) {
         Stop-Job $dismJob
@@ -298,15 +391,22 @@ data:
         Remove-Job $dismJob
       }
 
+      # Rename cached unattend.xml to prevent sysprep issues
       if (Test-Path "C:\Windows\Panther\unattend.xml") {
         Rename-Item "C:\Windows\Panther\unattend.xml" "C:\Windows\Panther\unattend.install.xml"
       }
 
+      # Eject CD
       try { (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject") } catch {}
     }
     finally {
+      # Disable Windows Update to prevent it from blocking shutdown
       Stop-Service wuauserv -Force -ErrorAction SilentlyContinue
       Set-Service wuauserv -StartupType Disabled -ErrorAction SilentlyContinue
+      if (-not $sshInstalled) {
+        Write-Host "ERROR: post-update.ps1 finished WITHOUT OpenSSH installed"
+      }
+      Stop-Transcript -ErrorAction SilentlyContinue
       Stop-Computer -Force
     }
 ---

--- a/scripts/check-ps1-sync.sh
+++ b/scripts/check-ps1-sync.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+MANIFEST="manifests/windows/golden-image.yaml"
+SCRIPT="scripts/windows/setup-golden-image.sh"
+RC=0
+
+check_block() {
+  local block_name="$1"
+  local end_pattern="$2"
+
+  local manifest_content
+  manifest_content=$(awk -v name="$block_name" -v endpat="$end_pattern" '
+    $0 ~ "^  " name ": \\|" {found=1; next}
+    found && $0 ~ endpat {exit}
+    found {sub(/^    /, ""); print}
+  ' "$MANIFEST")
+
+  local script_content
+  script_content=$(awk -v name="$block_name" '
+    $0 ~ "^  " name ": \\|" {found=1; next}
+    found && /^EOF$/ {exit}
+    found && $0 ~ "^  [a-zA-Z]" {exit}
+    found {sub(/^    /, ""); print}
+  ' "$SCRIPT" | sed 's/\\\$/$/g; s/\\\\/\\/g')
+
+  if ! diff <(printf '%s\n' "$manifest_content") <(printf '%s\n' "$script_content") >/dev/null 2>&1; then
+    echo "ERROR: $block_name is out of sync between:"
+    echo "  - $MANIFEST"
+    echo "  - $SCRIPT"
+    echo ""
+    diff --unified=3 <(printf '%s\n' "$manifest_content") <(printf '%s\n' "$script_content") || true
+    echo ""
+    RC=1
+  else
+    echo "OK: $block_name is in sync"
+  fi
+}
+
+check_block "post-update.ps1" "^---$"
+check_block "autounattend.xml" "^  post-update[.]ps1:"
+
+exit $RC

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -51,9 +51,7 @@ add_pvc_owner_reference() {
   echo "Found owner Job: ${job_name} (UID: ${job_uid})"
 
   # Patch PVC with owner reference
-  oc patch pvc "${pvc_name}" -n "${namespace}" --type=json -p "[{\"op\":\"add\",\"path\":\"/metadata/ownerReferences\",\"value\":[{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"name\":\"${job_name}\",\"uid\":\"${job_uid}\",\"controller\":true,\"blockOwnerDeletion\":true}]}]" 2>/dev/null
-
-  if [ $? -eq 0 ]; then
+  if oc patch pvc "${pvc_name}" -n "${namespace}" --type=json -p "[{\"op\":\"add\",\"path\":\"/metadata/ownerReferences\",\"value\":[{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"name\":\"${job_name}\",\"uid\":\"${job_uid}\",\"controller\":true,\"blockOwnerDeletion\":true}]}]" 2>/dev/null; then
     echo "Successfully added owner reference to PVC ${pvc_name}"
   else
     echo "Warning: Failed to add owner reference to PVC ${pvc_name}"
@@ -408,8 +406,8 @@ fi
 #   - Tool-created: ACCEPT_WINDOWS_EULA=true → runs pipeline
 # Exit code contract with setup-golden-image.sh (must stay in sync):
 #   0              = success or expected skip (BYOI ready, EULA not set)
-#   EXIT_WINDOWS_SKIP = prerequisite missing (e.g. Pipelines not installed) — skip gracefully
-#   anything else  = real failure (pipeline ran and failed, timeout, config error) — hard fail
+#   EXIT_WINDOWS_SKIP = prerequisite missing (no internet, pipeline not installed) — skip Windows gracefully, other suites continue
+#   anything else  = real failure (pipeline ran and failed, timeout, config error) — hard fail so CI detects it
 readonly EXIT_WINDOWS_SKIP=2
 
 WINDOWS_SETUP_SCRIPT="${SCRIPT_DIR}/windows/setup-golden-image.sh"
@@ -420,20 +418,15 @@ if [ -f "${WINDOWS_SETUP_SCRIPT}" ]; then
   export ACCEPT_WINDOWS_EULA
   WINDOWS_SETUP_EXIT=0
   bash "${WINDOWS_SETUP_SCRIPT}" || WINDOWS_SETUP_EXIT=$?
-  case $WINDOWS_SETUP_EXIT in
+  case ${WINDOWS_SETUP_EXIT} in
     0)
-      # Success or expected skip (BYOI ready, EULA not set)
       ;;
     "${EXIT_WINDOWS_SKIP}")
-      # Missing prerequisite: skip gracefully
-      # setup-golden-image.sh's EXIT trap already cleaned up its resources
       echo "WARNING: Windows golden image setup skipped (missing prerequisite). Windows tests will be skipped."
       echo "All other test suites will continue normally."
       unset ACCEPT_WINDOWS_EULA
       ;;
     *)
-      # Pipeline or setup failure: hard fail so CI detects the problem
-      # setup-golden-image.sh's EXIT trap already cleaned up its resources
       echo "ERROR: Windows golden image setup failed (exit ${WINDOWS_SETUP_EXIT}). Aborting validation."
       exit 1
       ;;

--- a/scripts/windows/setup-golden-image.sh
+++ b/scripts/windows/setup-golden-image.sh
@@ -82,6 +82,131 @@ cleanup_namespace() {
   cleanup_golden_image_resources "${GOLDEN_IMAGE_NAMESPACE}"
 }
 
+verify_ssh_on_golden_image() {
+  local test_vm_name="win-ssh-verify-$$"
+  local test_dv_name="${test_vm_name}-dv"
+  trap 'echo "Cleaning up test VM..."; oc delete vm "${test_vm_name}" -n "${GOLDEN_IMAGE_NAMESPACE}" --wait=false 2>/dev/null || true' RETURN
+  echo "Booting test VM '${test_vm_name}' from golden image to verify SSH..."
+
+  oc apply -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<VMEOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ${test_vm_name}
+  labels:
+    app: ocp-virt-validation
+spec:
+  runStrategy: Always
+  instancetype:
+    kind: VirtualMachineClusterInstancetype
+    name: ${INSTANCE_TYPE}
+  preference:
+    kind: VirtualMachineClusterPreference
+    name: windows.2k22
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 22
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: ${test_dv_name}
+  dataVolumeTemplates:
+    - metadata:
+        name: ${test_dv_name}
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: ${GOLDEN_IMAGE_NAME}
+          namespace: ${GOLDEN_IMAGE_NAMESPACE}
+        storage:
+          storageClassName: ${STORAGE_CLASS}
+          resources:
+            requests:
+              storage: 20Gi
+VMEOF
+
+  local verify_timeout=600
+  local elapsed=0
+  local agent_ready=false
+  echo "Waiting for test VM guest agent (up to ${verify_timeout}s)..."
+  while [ ${elapsed} -lt ${verify_timeout} ]; do
+    local agent_status
+    agent_status=$(oc get vmi "${test_vm_name}" -n "${GOLDEN_IMAGE_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[?(@.type=="AgentConnected")].status}' 2>/dev/null || echo "")
+    if [ "${agent_status}" == "True" ]; then
+      agent_ready=true
+      echo "Guest agent connected after ${elapsed}s"
+      break
+    fi
+    sleep 15
+    elapsed=$((elapsed + 15))
+  done
+
+  if [ "${agent_ready}" != "true" ]; then
+    echo "ERROR: Test VM guest agent did not connect within ${verify_timeout}s"
+    return 1
+  fi
+
+  # Give sshd a few seconds to start after boot
+  sleep 10
+
+  local launcher_pod=""
+  local lp_attempt
+  for lp_attempt in 1 2 3; do
+    launcher_pod=$(oc get pods -n "${GOLDEN_IMAGE_NAMESPACE}" \
+      -l "kubevirt.io=virt-launcher" --no-headers 2>/dev/null \
+      | grep "${test_vm_name}" | awk '{print $1}' | head -1)
+    [ -n "${launcher_pod}" ] && break
+    echo "  Waiting for launcher pod (attempt ${lp_attempt}/3)..."
+    sleep 5
+  done
+  if [ -z "${launcher_pod}" ]; then
+    echo "ERROR: Could not find launcher pod for test VM"
+    echo "  Pods in namespace:"
+    oc get pods -n "${GOLDEN_IMAGE_NAMESPACE}" --no-headers 2>/dev/null || true
+    return 1
+  fi
+  echo "Found launcher pod: ${launcher_pod}"
+
+  local ssh_ok=false
+  local attempt
+  for attempt in 1 2 3 4 5 6; do
+    echo "  SSH check attempt ${attempt}/6 on 127.0.0.1:22 (via compute container)..."
+    if oc exec -n "${GOLDEN_IMAGE_NAMESPACE}" "${launcher_pod}" -c compute -- \
+        timeout 10 bash -c "echo '' > /dev/tcp/127.0.0.1/22" 2>/dev/null; then
+      ssh_ok=true
+      echo "  Port 22 is OPEN — SSH is working!"
+      break
+    fi
+    echo "  Port 22 not ready yet, waiting 15s..."
+    sleep 15
+  done
+
+  if [ "${ssh_ok}" == "true" ]; then
+    echo "SSH verification PASSED"
+    return 0
+  else
+    echo "ERROR: SSH verification FAILED — port 22 is not open on the golden image"
+    echo "OpenSSH was likely not installed during Windows setup."
+    echo "Check the post-update.ps1 transcript (C:\\post-update.log) inside the golden image for details."
+    return 1
+  fi
+}
+
 dump_windows_debug_info() {
   echo "=== Windows Setup Debug Info ==="
 
@@ -208,13 +333,14 @@ EOF
         echo "Pipeline completed successfully!"
         break
         ;;
-      "Failed"|"PipelineRunTimeout"|"TaskRunCancelled"|"CouldntGetPipeline")
-        if [ "${STATUS}" == "CouldntGetPipeline" ]; then
-          echo "ERROR: Failed to fetch pipeline from artifacthub."
-          echo "For disconnected environments, manually install the pipeline first:"
-          echo "  https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer"
-          exit 1
-        fi
+      "CouldntGetPipeline"|"CouldntGetTask")
+        echo "ERROR: Failed to resolve pipeline/tasks from Artifact Hub (status: ${STATUS})."
+        echo "The Tekton hub resolver requires internet access."
+        echo "In disconnected environments, provide your own golden image (BYOI) instead of using ACCEPT_WINDOWS_EULA."
+        echo "See: disconnected/README.md"
+        exit ${EXIT_WINDOWS_SKIP}
+        ;;
+      "Failed"|"PipelineRunTimeout"|"TaskRunCancelled")
         echo "ERROR: Pipeline failed with status: ${STATUS}"
         oc get pipelinerun "${PIPELINE_RUN_NAME}" -n "${GOLDEN_IMAGE_NAMESPACE}" -o yaml | tail -50
         exit 1
@@ -355,6 +481,20 @@ data:
           </UserData>
         </component>
       </settings>
+      <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <ComputerName>*</ComputerName>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <RunSynchronous>
+            <RunSynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <Path>reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Network\\NewNetworkWindowOff" /f</Path>
+              <Description>Suppress network location dialog</Description>
+            </RunSynchronousCommand>
+          </RunSynchronous>
+        </component>
+      </settings>
       <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <InputLocale>0409:00000409</InputLocale>
@@ -399,21 +539,99 @@ data:
       </settings>
     </unattend>
   post-update.ps1: |
+    Start-Transcript -Path "C:\\post-update.log" -Force
+    \$sshInstalled = \$false
     try {
-      \$ErrorActionPreference = 'Stop'
+      # Install QEMU guest agent (with timeout to avoid hangs)
+      \$gaJob = Start-Job { \$p = Start-Process msiexec -Wait -PassThru -ArgumentList "/i E:\\guest-agent\\qemu-ga-x86_64.msi /qn /norestart"; \$p.ExitCode }
+      if (-not (Wait-Job \$gaJob -Timeout 120)) {
+        Stop-Job \$gaJob; Remove-Job \$gaJob -Force
+        Write-Host "WARNING: QEMU guest agent installer timed out after 120s -- continuing"
+      } else {
+        \$exitCode = Receive-Job \$gaJob; Remove-Job \$gaJob
+        if (\$exitCode -ne 0 -and \$exitCode -ne 3010) {
+          Write-Host "WARNING: QEMU guest agent installer exited \$exitCode -- continuing"
+        }
+      }
 
-      # Install QEMU guest agent
-      Start-Process msiexec -Wait -ArgumentList "/i E:\\guest-agent\\qemu-ga-x86_64.msi /qn /passive /norestart"
+      # Disable Windows Firewall first (ensures VM is reachable regardless of SSH outcome)
+      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False -ErrorAction Stop
 
-      # Install and start OpenSSH server
-      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-      Set-Service -Name sshd -StartupType Automatic
-      Start-Service sshd
+      # Wait for network connectivity before OpenSSH install (DHCP + DNS can take time during OOBE)
+      Write-Host "Waiting for network connectivity..."
+      \$netReady = \$false
+      for (\$i = 0; \$i -lt 30; \$i++) {
+        \$addrs = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+          Where-Object { \$_.IPAddress -ne '127.0.0.1' -and \$_.PrefixOrigin -ne 'WellKnown' }
+        if (\$addrs) {
+          Write-Host "IPv4 address acquired: \$(\$addrs[0].IPAddress) on \$(\$addrs[0].InterfaceAlias)"
+          try {
+            [System.Net.Dns]::GetHostAddresses('github.com') | Out-Null
+            Write-Host "DNS resolution verified"
+            \$netReady = \$true
+            break
+          } catch {
+            Write-Host "  DNS not ready yet (attempt \$i)..."
+          }
+        } else {
+          Write-Host "  No IPv4 address yet (attempt \$i)..."
+        }
+        Start-Sleep -Seconds 5
+      }
+      if (-not \$netReady) {
+        Write-Host "WARNING: Network not fully ready after 150s -- OpenSSH online methods may fail"
+      }
 
-      # Disable Windows Firewall entirely
-      Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+      # Install OpenSSH server with fallback methods
+      try {
+        Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -LimitAccess -ErrorAction Stop
+        Write-Host "OpenSSH installed via local capability store (-LimitAccess)"
+      } catch {
+        Write-Host "OpenSSH local install (-LimitAccess) failed: \$(\$_). Trying online method (300s timeout)..."
+        try {
+          \$job = Start-Job { Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop }
+          if (-not (Wait-Job \$job -Timeout 300)) {
+            Stop-Job \$job; Remove-Job \$job -Force
+            throw "Add-WindowsCapability online timed out after 300s"
+          }
+          Receive-Job \$job -ErrorAction Stop; Remove-Job \$job
+          Write-Host "OpenSSH installed via Windows Update (online)"
+        } catch {
+          Write-Host "OpenSSH online install failed: \$(\$_). Trying GitHub MSI fallback..."
+          try {
+            # Win32-OpenSSH stable releases only ship .zip archives; MSI installers are Preview-only.
+            # When updating, change both the URL and expectedHash together.
+            # Hash: SHA-256 of the official GitHub release artifact.
+            # Verify with: (Get-FileHash OpenSSH-Win64-v10.0.0.0.msi -Algorithm SHA256).Hash
+            \$url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi'
+            \$expectedHash = 'ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9'
+            \$msi = "\$env:TEMP\\OpenSSH-Win64.msi"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+            Invoke-WebRequest -Uri \$url -OutFile \$msi -UseBasicParsing -TimeoutSec 120 -ErrorAction Stop
+            \$actualHash = (Get-FileHash \$msi -Algorithm SHA256).Hash.ToLower()
+            if (\$actualHash -ne \$expectedHash) {
+              throw "OpenSSH MSI hash mismatch (expected \$expectedHash, got \$actualHash)"
+            }
+            \$msiProc = Start-Process msiexec -Wait -PassThru -ArgumentList "/i \$msi /qn /norestart"
+            if (\$msiProc.ExitCode -ne 0 -and \$msiProc.ExitCode -ne 3010) {
+              throw "OpenSSH MSI installer failed with exit code \$(\$msiProc.ExitCode)"
+            }
+            Write-Host "OpenSSH installed via GitHub MSI (exit code: \$(\$msiProc.ExitCode))"
+          } catch {
+            throw "FATAL: All OpenSSH installation methods failed. Last error: \$(\$_)"
+          }
+        }
+      }
 
-      \$ErrorActionPreference = 'Continue'
+      Set-Service -Name sshd -StartupType Automatic -ErrorAction Stop
+      Start-Service sshd -ErrorAction Stop
+      \$sshdStatus = (Get-Service sshd).Status
+      if (\$sshdStatus -ne 'Running') {
+        throw "FATAL: sshd service is not running (status: \$sshdStatus)"
+      }
+      Write-Host "OpenSSH sshd service is running and set to auto-start"
+      \$sshInstalled = \$true
+
 
       # Suppress network location wizard and set profile
       New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
@@ -448,7 +666,10 @@ data:
       # Disable Windows Update to prevent it from blocking shutdown
       Stop-Service wuauserv -Force -ErrorAction SilentlyContinue
       Set-Service wuauserv -StartupType Disabled -ErrorAction SilentlyContinue
-      # Always shut down, even if errors occurred above
+      if (-not \$sshInstalled) {
+        Write-Host "ERROR: post-update.ps1 finished WITHOUT OpenSSH installed"
+      }
+      Stop-Transcript -ErrorAction SilentlyContinue
       Stop-Computer -Force
     }
 EOF
@@ -635,10 +856,24 @@ if [ "${DS_READY}" != "True" ]; then
   exit 1
 fi
 
-# Cleanup pipeline resources (SA, autounattend CM)
-trap - EXIT
+# Cleanup pipeline resources (SA, autounattend CM) — these are safe to remove
+# before verification since they're only needed during the pipeline run.
 cleanup_pipeline_sa
 cleanup_autounattend_cm
+
+echo ""
+echo "=== Verifying Golden Image ==="
+# Run verify while EXIT trap is still armed so dump_windows_debug_info fires on failure.
+if ! verify_ssh_on_golden_image; then
+  echo ""
+  echo "FATAL: Golden image SSH verification failed."
+  echo "Check C:\\post-update.log inside the golden image for the actual cause"
+  echo "(guest agent install, OpenSSH install, or other setup failure)."
+  exit 1
+fi
+
+# Image verified — clear trap and do final cleanup
+trap - EXIT
 
 echo ""
 echo "=== Windows Server 2022 Golden Image Setup Complete ==="


### PR DESCRIPTION
## Problem

The Windows golden image pipeline was silently producing images without OpenSSH installed. Tests that SSH into Windows VMs would fail with connection timeouts, but the pipeline reported success.

## Redesign

### OpenSSH 3-step fallback
Replaced the single `Add-WindowsCapability -Online` call with a fallback chain:
1. Local capability store (`-LimitAccess`)
2. Windows Update (online, 300s timeout)
3. GitHub MSI download (SHA-256 verified, TLS 1.2+1.3, hash provenance documented)

### Network wait before install
`post-update.ps1` now waits up to 150s for IPv4 + DNS before attempting OpenSSH install — prevents failures when DHCP/DNS aren't ready during OOBE.

### SSH verification after pipeline
New `verify_ssh_on_golden_image()` boots a temporary VM (`win-ssh-verify-*`) from the DataSource with an explicit masquerade interface forwarding port 22, and confirms port 22 is open. If SSH isn't working the entire checkup aborts with `exit 1` — check `C:\post-update.log` inside the golden image for diagnosis. Test VM cleanup is handled via `trap RETURN` (single path, no drift).

### Graceful skip on disconnected clusters
When Tekton hub resolver fails (`CouldntGetPipeline`/`CouldntGetTask`), Windows tests are skipped (`exit 2`) instead of aborting the run. Other failures (ISO download, timeout, SSH verification) still exit 1. `ACCEPT_WINDOWS_EULA` is connected-only; disconnected users should use BYOI.

### CI sync check
Added `scripts/check-ps1-sync.sh` + GitHub Actions step ("Check Windows ConfigMap sync") that extracts and diffs the `post-update.ps1` block from both `setup-golden-image.sh` and `manifests/windows/golden-image.yaml`, failing the build if they diverge.

## Documentation
- `README.md` "How It Works" updated with the SSH verify step, its blast radius (full abort on failure), and a pointer to `C:\post-update.log`
- `disconnected/README.md` rewritten: BYOI-first flow, explicit requirements, removed inline DataVolume YAML (points to manifest Method 2 instead), qualified graceful-skip claim
- Removed dead `ssh-ready.marker` write (never read — verify uses TCP port probe)

## Other changes
- QEMU guest agent install wrapped with 120s timeout
- `autounattend.xml`: added specialize pass to suppress network location dialog
- `manifests/windows/golden-image.yaml` synced with setup script
- `verify_ssh_on_golden_image`: local variables lowercased, loop vars (`lp_attempt`, `attempt`) declared `local`
- Shellcheck fix in `entrypoint.sh`