### PR TITLE
feat: simulate true disconnected scenario for Windows golden image testing

### DIFF
--- a/ci/disconnected-windows-hub-resolver-bug.md
+++ b/ci/disconnected-windows-hub-resolver-bug.md
@@ -1,0 +1,73 @@
+# Bug: Windows golden image setup fails hard in truly disconnected environments
+
+## Summary
+
+In a truly disconnected cluster, `setup-golden-image.sh` exits with code 1 when
+the Tekton hub resolver cannot reach ArtifactHub/GitHub to download the
+`windows-efi-installer` pipeline. This causes the entire validation run to abort
+instead of gracefully skipping Windows tests.
+
+## Root cause
+
+`setup-golden-image.sh` creates the PipelineRun with `resolver: hub`:
+
+```yaml
+pipelineRef:
+  resolver: hub
+  params:
+    - name: catalog
+      value: redhat-pipelines
+    - name: kind
+      value: pipeline
+    - name: name
+      value: windows-efi-installer
+```
+
+The hub resolver always fetches remotely from ArtifactHub (`artifacthub.io`) and
+may pull pipeline task definitions from `github.com` or `raw.githubusercontent.com`.
+In a disconnected environment none of these are reachable, so Tekton reports
+`CouldntGetPipeline`.
+
+The error handler currently exits with code 1 (hard failure):
+
+```bash
+"CouldntGetPipeline")
+  echo "ERROR: Failed to fetch pipeline from artifacthub."
+  echo "For disconnected environments, manually install the pipeline first:"
+  echo "  https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer"
+  exit 1   # aborts all test suites, not just Windows
+  ;;
+```
+
+## Impact
+
+- All test suites (compute, network, storage, ssp, tier2) are aborted, not just Windows.
+- The error message points to an ArtifactHub URL that is also unreachable in disconnected mode.
+
+## Expected behaviour
+
+- `CouldntGetPipeline` should exit with `EXIT_WINDOWS_SKIP` (2) so only Windows tests
+  are skipped and all other suites continue normally.
+- The error message should instruct the user to pre-install the pipeline from a local
+  mirror before going disconnected.
+
+## Proposed fix
+
+1. Change `exit 1` to `exit ${EXIT_WINDOWS_SKIP}` for the `CouldntGetPipeline` case.
+2. Update the error message with actionable disconnected instructions (download pipeline
+   YAML before disconnecting, apply with `oc apply -f pipeline.yaml -n <namespace>`).
+3. Add support for a pre-installed `Pipeline` resource: when a `Pipeline` named
+   `windows-efi-installer` already exists in the namespace, use `pipelineRef.name`
+   instead of `pipelineRef.resolver: hub`.
+
+## Related
+
+- CNV-94759: Simulate true disconnected scenario for Windows golden image testing
+- `scripts/windows/setup-golden-image.sh`: `CouldntGetPipeline` handler and PipelineRun spec
+
+## Notes
+
+_Tested 2026-08-07: blocking `github.com` and `objects.githubusercontent.com` does NOT
+trigger `CouldntGetPipeline`. The hub resolver only needs `artifacthub.io` — pipeline
+resolved successfully with those domains blocked. The failure described above only
+applies when `artifacthub.io` itself is unreachable (fully air-gapped cluster)._

--- a/ci/run-ci-validation-disconnected.sh
+++ b/ci/run-ci-validation-disconnected.sh
@@ -11,9 +11,23 @@ PULL_SECRET="${PULL_SECRET:-}"
 DRY_RUN="${DRY_RUN:-true}"
 OCP_VIRT_VALIDATION_TIMEOUT="${OCP_VIRT_VALIDATION_TIMEOUT:-10m}"
 ACCEPT_WINDOWS_EULA="${ACCEPT_WINDOWS_EULA:-false}"
+CLEANUP_MIRRORS="${CLEANUP_MIRRORS:-false}"
+
+cleanup_mirror_resources() {
+  oc delete imagetagmirrorset ocp-virt-validation-mirrors --ignore-not-found=true || true
+  oc delete imagedigestmirrorset ocp-virt-validation-digest-mirrors --ignore-not-found=true || true
+  oc delete namespace kubevirt-mirror --ignore-not-found=true --wait=true --timeout=5m || true
+}
 
 cleanup() {
   rm -f "${CLUSTER_PULL_SECRET:-}" 2>/dev/null || true
+  if [ "${CLEANUP_MIRRORS}" = "true" ]; then
+    echo "=== Cleaning up mirror sets (CLEANUP_MIRRORS=true) ==="
+    cleanup_mirror_resources
+    echo "Waiting for MachineConfigPools to stabilize..."
+    oc wait machineconfigpool --all --for=condition=Updated --timeout=30m || true
+    echo "> Mirror cleanup complete"
+  fi
 }
 trap cleanup EXIT
 
@@ -34,9 +48,7 @@ echo "> Pre-flight checks passed"
 
 echo "=== Cleaning up previous runs ==="
 for node in $(oc get node -o NAME); do oc debug -n default "${node}" -- chroot /host crictl rmi --prune; done || true
-oc delete imagetagmirrorset ocp-virt-validation-mirrors --ignore-not-found=true || true
-oc delete imagedigestmirrorset ocp-virt-validation-digest-mirrors --ignore-not-found=true || true
-oc delete namespace kubevirt-mirror --ignore-not-found=true --wait=true || true
+cleanup_mirror_resources
 oc delete namespace ocp-virt-validation --ignore-not-found=true --wait=true || true
 echo "Waiting for MachineConfigPools to stabilize..."
 oc wait machineconfigpool --all --for=condition=Updated --timeout=30m
@@ -90,6 +102,69 @@ if [ -n "${OCP_VIRT_VALIDATION_IMAGE:-}" ]; then
   OCP_VIRT_VALIDATION_IMAGE=$("${SCRIPT_DIR}/mirror-checkup-image-to-internal-registry.sh" \
     "${OCP_VIRT_VALIDATION_IMAGE}" "${INTERNAL_REGISTRY}")
   echo "> Using in-cluster image: ${OCP_VIRT_VALIDATION_IMAGE}"
+fi
+
+if [ "${ACCEPT_WINDOWS_EULA}" = "true" ]; then
+  echo "=== Preparing disconnected Windows test ==="
+  GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
+
+  # Pre-create the namespace so resources are ready before the Tekton pipeline
+  # launches inside the checkup pod. setup-golden-image.sh reuses it when
+  # it finds the app=ocp-virt-validation label.
+  if ! oc get namespace "${GOLDEN_IMAGE_NAMESPACE}" &>/dev/null; then
+    oc create namespace "${GOLDEN_IMAGE_NAMESPACE}"
+    oc label namespace "${GOLDEN_IMAGE_NAMESPACE}" \
+      app=ocp-virt-validation \
+      pod-security.kubernetes.io/enforce=privileged \
+      --overwrite
+  fi
+
+  echo "=== Mirroring Windows ISO to internal cluster server ==="
+  WIN_IMAGE_DOWNLOAD_URL=$(GOLDEN_IMAGE_NAMESPACE="${GOLDEN_IMAGE_NAMESPACE}" \
+    "${SCRIPT_DIR}/setup-windows-iso-mirror.sh")
+  export WIN_IMAGE_DOWNLOAD_URL
+  echo "> Windows ISO URL: ${WIN_IMAGE_DOWNLOAD_URL}"
+
+  echo "=== Blocking Microsoft Update egress for disconnected Windows test ==="
+  oc apply -n "${GOLDEN_IMAGE_NAMESPACE}" -f - <<'EFEOF'
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  labels:
+    app: ocp-virt-validation
+spec:
+  egress:
+  - type: Deny
+    to:
+      dnsName: software-static.download.prss.microsoft.com
+  - type: Deny
+    to:
+      dnsName: windowsupdate.microsoft.com
+  - type: Deny
+    to:
+      dnsName: download.windowsupdate.com
+  - type: Deny
+    to:
+      dnsName: update.microsoft.com
+  - type: Deny
+    to:
+      dnsName: fe2cr.update.microsoft.com
+  - type: Deny
+    to:
+      dnsName: sls.update.microsoft.com
+  - type: Deny
+    to:
+      dnsName: github.com
+  - type: Deny
+    to:
+      dnsName: objects.githubusercontent.com
+  - type: Allow
+    to:
+      cidrSelector: 0.0.0.0/0
+EFEOF
+
+  echo "> EgressFirewall applied to namespace ${GOLDEN_IMAGE_NAMESPACE}"
 fi
 
 echo "=== Running disconnected validation checkup ==="

--- a/ci/setup-windows-iso-mirror.sh
+++ b/ci/setup-windows-iso-mirror.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+#
+# Mirror the Windows Server 2022 ISO to an in-cluster HTTP server.
+#
+# Downloads the ISO into a PVC and serves it via nginx so the
+# windows-efi-installer Tekton pipeline can fetch it without reaching
+# software-static.download.prss.microsoft.com.
+#
+# Prints the ISO HTTP URL on stdout. All other output goes to stderr.
+# Idempotent: if the server is already running, returns the URL immediately.
+#
+# Caller must export WIN_IMAGE_DOWNLOAD_URL with the returned URL before
+# running run-ci-validation.sh, and add software-static.download.prss.microsoft.com
+# to the EgressFirewall block list.
+#
+# Environment:
+#   GOLDEN_IMAGE_NAMESPACE   namespace for all resources (default: validation-os-images)
+#   WIN_IMAGE_DOWNLOAD_URL   source ISO URL (default: Microsoft Server 2022 eval)
+#   STORAGE_CLASS            storage class for the PVC (default: cluster default)
+
+set -euo pipefail
+
+NAMESPACE="${GOLDEN_IMAGE_NAMESPACE:-validation-os-images}"
+DEFAULT_ISO_URL="https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso"
+SOURCE_ISO_URL="${WIN_IMAGE_DOWNLOAD_URL:-${DEFAULT_ISO_URL}}"
+ISO_FILENAME="windows-server-2022.iso"
+ISO_PVC="windows-iso-cache"
+ISO_SERVER="windows-iso-server"
+STORAGE_CLASS="${STORAGE_CLASS:-}"
+PVC_SIZE="8Gi"
+DOWNLOADER_IMAGE="registry.redhat.io/ubi9/ubi-minimal:latest"
+NGINX_IMAGE="registry.redhat.io/rhel9/nginx-124:latest"
+
+err() { echo "$*" >&2; }
+
+# Idempotent: return immediately if server already running with ISO present
+EXISTING_ROUTE=$(oc get route "${ISO_SERVER}" -n "${NAMESPACE}" \
+  -o jsonpath='{.spec.host}' 2>/dev/null || true)
+if [ -n "${EXISTING_ROUTE}" ]; then
+  PVC_PHASE=$(oc get pvc "${ISO_PVC}" -n "${NAMESPACE}" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [ "${PVC_PHASE}" = "Bound" ]; then
+    err "> ISO server already running at http://${EXISTING_ROUTE}/${ISO_FILENAME}"
+    echo "http://${EXISTING_ROUTE}/${ISO_FILENAME}"
+    exit 0
+  fi
+fi
+
+err "=== Creating ISO cache PVC (${PVC_SIZE}) ==="
+SC_LINE=""
+[ -n "${STORAGE_CLASS}" ] && SC_LINE="storageClassName: ${STORAGE_CLASS}"
+oc apply -n "${NAMESPACE}" -f - >&2 <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${ISO_PVC}
+  labels:
+    app: ocp-virt-validation
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: ${PVC_SIZE}
+  ${SC_LINE}
+EOF
+
+err "=== Downloading ISO into cluster PVC (this may take a while) ==="
+oc delete job windows-iso-downloader -n "${NAMESPACE}" --ignore-not-found=true --wait=true >&2
+
+oc create -n "${NAMESPACE}" -f - >&2 <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: windows-iso-downloader
+  labels:
+    app: ocp-virt-validation
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app: ocp-virt-validation
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+      - name: downloader
+        image: ${DOWNLOADER_IMAGE}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+            if [ -f "/data/${ISO_FILENAME}" ]; then
+              echo "ISO already present, skipping download"
+              exit 0
+            fi
+            echo "Downloading from ${SOURCE_ISO_URL}..."
+            curl -L --retry 3 --retry-delay 10 --progress-bar \
+              -o "/data/${ISO_FILENAME}.tmp" "${SOURCE_ISO_URL}"
+            mv "/data/${ISO_FILENAME}.tmp" "/data/${ISO_FILENAME}"
+            echo "Download complete: \$(du -sh /data/${ISO_FILENAME})"
+        volumeMounts:
+        - name: iso-data
+          mountPath: /data
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+      volumes:
+      - name: iso-data
+        persistentVolumeClaim:
+          claimName: ${ISO_PVC}
+EOF
+
+err "Waiting for ISO download to complete (timeout: 3h)..."
+oc wait job/windows-iso-downloader -n "${NAMESPACE}" \
+  --for=condition=complete --timeout=3h >&2
+
+err "=== Deploying ISO HTTP server ==="
+oc apply -n "${NAMESPACE}" -f - >&2 <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${ISO_SERVER}
+  labels:
+    app: ocp-virt-validation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${ISO_SERVER}
+  template:
+    metadata:
+      labels:
+        app: ${ISO_SERVER}
+        app.kubernetes.io/part-of: ocp-virt-validation
+    spec:
+      containers:
+      - name: nginx
+        image: ${NGINX_IMAGE}
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: iso-data
+          mountPath: /opt/app-root/src
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      volumes:
+      - name: iso-data
+        persistentVolumeClaim:
+          claimName: ${ISO_PVC}
+          readOnly: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${ISO_SERVER}
+  labels:
+    app: ocp-virt-validation
+spec:
+  selector:
+    app: ${ISO_SERVER}
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ${ISO_SERVER}
+  labels:
+    app: ocp-virt-validation
+spec:
+  to:
+    kind: Service
+    name: ${ISO_SERVER}
+  port:
+    targetPort: 8080
+EOF
+
+err "Waiting for ISO server to be ready..."
+oc rollout status deployment/${ISO_SERVER} -n "${NAMESPACE}" --timeout=5m >&2
+
+ROUTE=$(oc get route "${ISO_SERVER}" -n "${NAMESPACE}" -o jsonpath='{.spec.host}')
+err "> ISO server ready: http://${ROUTE}/${ISO_FILENAME}"
+echo "http://${ROUTE}/${ISO_FILENAME}"


### PR DESCRIPTION
## Summary

- Add `ci/setup-windows-iso-mirror.sh`: downloads the Windows Server 2022 ISO into a cluster PVC and serves it via nginx, so the Tekton pipeline can fetch it from an internal URL instead of `software-static.download.prss.microsoft.com`
- Apply an OVN-K `EgressFirewall` (name must be `default` per OVN-K constraint) to `validation-os-images` before the pipeline runs, blocking `software-static.download.prss.microsoft.com`, Microsoft Update endpoints, `github.com`, and `objects.githubusercontent.com`
- Extract `cleanup_mirror_resources()` shared by the initial run cleanup and a new `CLEANUP_MIRRORS=true` post-run trap, so ITMS/IDMS/`kubevirt-mirror` are removed from the cluster when reusing it across runs
- Add `ci/disconnected-windows-hub-resolver-bug.md` documenting that the hub resolver only needs `artifacthub.io` (blocking `github.com` does not break it), and when the bug applies (fully air-gapped clusters without `artifacthub.io`)

## What this PR does / why we need it

The existing disconnected Prow step (`run-validation-checkup-disconnected`) is pseudo-disconnected: only container image registries are redirected via ITMS/IDMS, but the cluster retains full outbound internet access. As a result, `Add-WindowsCapability -Online` in the Windows golden image pipeline silently succeeds by reaching Microsoft Update servers. The `-LimitAccess` fallback introduced in PR #100 is never exercised.

This PR simulates a true disconnected scenario by:
1. Mirroring the Windows ISO internally so `software-static.download.prss.microsoft.com` can be blocked
2. Applying a namespace-scoped `EgressFirewall` that blocks all Microsoft Update endpoints and `github.com` before the Tekton pipeline runs
3. Forcing `Add-WindowsCapability -Online` to fail so the `-LimitAccess` fallback is validated in CI

New env vars:
- `CLEANUP_MIRRORS=true` — remove ITMS/IDMS/`kubevirt-mirror` after the run (useful when reusing a cluster)

## Test plan

- [ ] Run `KUBECONFIG=... ACCEPT_WINDOWS_EULA=true DRY_RUN=false OCP_VIRT_VALIDATION_TIMEOUT=4h ./ci/run-ci-validation-disconnected.sh` and verify:
  - ISO downloaded into cluster PVC and served via nginx Route
  - EgressFirewall `default` in `validation-os-images` with status `EgressFirewall Rules applied`
  - Windows golden image pipeline uses the internal ISO URL
  - `Add-WindowsCapability -Online` fails (MS Update blocked) and `-LimitAccess` fallback succeeds (requires PR #100)
  - `test_windows_memory_dump` passes

## Related

- [CNV-94759](https://redhat.atlassian.net/browse/CNV-94759)
- PR #100 (OpenSSH `-LimitAccess` fallback) must be merged before or alongside this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)